### PR TITLE
style: unify new event form styling

### DIFF
--- a/src/frontend/EventOrganizerWeb/src/index.css
+++ b/src/frontend/EventOrganizerWeb/src/index.css
@@ -2,7 +2,36 @@
 @tailwind components;
 @tailwind utilities;
 
-:root { color-scheme: dark; }
+:root {
+  color-scheme: dark;
+  --ne-surface: #12121b;
+  --ne-surface-alt: #181827;
+  --ne-surface-soft: rgba(255, 255, 255, 0.04);
+  --ne-border: rgba(255, 255, 255, 0.12);
+  --ne-border-strong: rgba(255, 255, 255, 0.18);
+  --ne-shadow-sm: 0 10px 30px rgba(0, 0, 0, 0.35);
+  --ne-shadow-md: 0 16px 40px rgba(0, 0, 0, 0.4);
+  --ne-text-strong: rgba(255, 255, 255, 0.92);
+  --ne-text: rgba(255, 255, 255, 0.85);
+  --ne-text-muted: rgba(255, 255, 255, 0.65);
+  --ne-text-faint: rgba(255, 255, 255, 0.45);
+  --ne-note-bg: rgba(139, 92, 246, 0.12);
+  --ne-note-border: rgba(139, 92, 246, 0.35);
+  --ne-pill-bg: rgba(139, 92, 246, 0.18);
+  --ne-pill-text: rgba(255, 255, 255, 0.9);
+  --ne-table-head: rgba(255, 255, 255, 0.08);
+  --ne-table-row-alt: rgba(255, 255, 255, 0.03);
+  --ne-btn-primary: #8b5cf6;
+  --ne-btn-primary-hover: #7c3aed;
+  --ne-btn-secondary: rgba(255, 255, 255, 0.1);
+  --ne-btn-secondary-hover: rgba(255, 255, 255, 0.18);
+  --ne-btn-danger: #ef4444;
+  --ne-btn-danger-hover: #dc2626;
+  --ne-input-bg: rgba(24, 24, 39, 0.92);
+  --ne-input-border: rgba(255, 255, 255, 0.16);
+  --ne-input-border-focus: rgba(139, 92, 246, 0.65);
+  --ne-input-shadow-focus: 0 0 0 3px rgba(139, 92, 246, 0.25);
+}
 html, body, #root { height: 100%; }
 body { @apply bg-bg text-white; }
 
@@ -13,3 +42,88 @@ body { @apply bg-bg text-white; }
 .btn-primary { @apply bg-primary hover:bg-primary/90 text-white; }
 .btn-subtle { @apply bg-white/10 hover:bg-white/15; }
 .link { @apply text-accent hover:underline; }
+
+/* Shared helpers for new-event forms */
+.ne-panel {
+  background: var(--ne-surface);
+  border: 1px solid var(--ne-border);
+  border-radius: 18px;
+  box-shadow: var(--ne-shadow-sm);
+}
+
+.ne-note {
+  background: var(--ne-note-bg);
+  border: 1px solid var(--ne-note-border);
+  color: var(--ne-text);
+  border-radius: 14px;
+}
+
+.ne-field-control {
+  background: var(--ne-input-bg);
+  border: 1px solid var(--ne-input-border);
+  color: var(--ne-text);
+  border-radius: 10px;
+  padding: 10px 12px;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
+}
+
+.ne-field-control:focus {
+  outline: none;
+  border-color: var(--ne-input-border-focus);
+  box-shadow: var(--ne-input-shadow-focus);
+}
+
+.ne-field-control:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.ne-btn {
+  border-radius: 12px;
+  border: 1px solid transparent;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 10px 18px;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease, border-color 0.15s ease;
+}
+
+.ne-btn:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+.ne-btn--primary {
+  background: var(--ne-btn-primary);
+  color: #fff;
+  box-shadow: 0 10px 28px rgba(139, 92, 246, 0.35);
+}
+
+.ne-btn--primary:not(:disabled):hover {
+  background: var(--ne-btn-primary-hover);
+  transform: translateY(-1px);
+}
+
+.ne-btn--secondary {
+  background: var(--ne-btn-secondary);
+  border-color: var(--ne-border-strong);
+  color: var(--ne-text);
+}
+
+.ne-btn--secondary:not(:disabled):hover {
+  background: var(--ne-btn-secondary-hover);
+  border-color: var(--ne-border-strong);
+  transform: translateY(-1px);
+}
+
+.ne-btn--danger {
+  background: var(--ne-btn-danger);
+  color: #fff;
+}
+
+.ne-btn--danger:not(:disabled):hover {
+  background: var(--ne-btn-danger-hover);
+  transform: translateY(-1px);
+}

--- a/src/frontend/EventOrganizerWeb/src/styles/NewEvent/NewEvent.css
+++ b/src/frontend/EventOrganizerWeb/src/styles/NewEvent/NewEvent.css
@@ -7,39 +7,46 @@
 .publish-btn,
 .publish-btn-secondary {
   padding: 10px 18px;
-  border-radius: 8px;
-  border: none;
+  border-radius: 12px;
+  border: 1px solid transparent;
   font-weight: 600;
   cursor: pointer;
-  transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease, border-color 0.15s ease;
 }
 
 .publish-btn {
-  background: #2563eb;
+  background: var(--ne-btn-primary);
   color: #fff;
+  box-shadow: 0 10px 28px rgba(139, 92, 246, 0.35);
 }
 
 .publish-btn:hover:not([disabled]) {
   transform: translateY(-1px);
-  box-shadow: 0 8px 16px rgba(37, 99, 235, 0.2);
+  background: var(--ne-btn-primary-hover);
 }
 
 .publish-btn:disabled {
-  opacity: 0.6;
+  opacity: 0.55;
   cursor: not-allowed;
   box-shadow: none;
+  transform: none;
 }
 
 .publish-btn-secondary {
-  background: #e2e8f0;
-  color: #1e293b;
+  background: var(--ne-btn-secondary);
+  border-color: var(--ne-border-strong);
+  color: var(--ne-text);
   margin-left: 12px;
+}
+
+.publish-btn-secondary:hover:not([disabled]) {
+  background: var(--ne-btn-secondary-hover);
 }
 
 .publish-modal__backdrop {
   position: fixed;
   inset: 0;
-  background: rgba(15, 23, 42, 0.55);
+  background: rgba(5, 6, 12, 0.75);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -47,21 +54,24 @@
 }
 
 .publish-modal {
-  background: #ffffff;
+  background: var(--ne-surface);
   width: min(720px, 90%);
-  border-radius: 16px;
-  box-shadow: 0 20px 50px rgba(15, 23, 42, 0.25);
+  border-radius: 20px;
+  box-shadow: var(--ne-shadow-md);
   display: flex;
   flex-direction: column;
   max-height: 80vh;
+  border: 1px solid var(--ne-border);
+  color: var(--ne-text);
 }
 
 .publish-modal__head {
   padding: 20px 24px;
-  border-bottom: 1px solid #e2e8f0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 12px;
 }
 
 .publish-modal__body {
@@ -72,7 +82,7 @@
 
 .publish-modal__actions {
   padding: 16px 24px;
-  border-top: 1px solid #e2e8f0;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
   display: flex;
   justify-content: flex-end;
   gap: 12px;
@@ -80,14 +90,15 @@
 
 .publish-modal__status {
   font-weight: 600;
-  color: #1e293b;
+  color: var(--ne-text-strong);
 }
 
 .publish-modal__error {
-  background: #fee2e2;
-  color: #991b1b;
-  border-radius: 8px;
+  background: rgba(239, 68, 68, 0.18);
+  color: #fecaca;
+  border-radius: 12px;
   padding: 12px 14px;
+  border: 1px solid rgba(239, 68, 68, 0.35);
 }
 
 .publish-modal__content section {
@@ -98,22 +109,23 @@
   margin-bottom: 6px;
   font-size: 1rem;
   font-weight: 600;
-  color: #1e293b;
+  color: var(--ne-text-strong);
 }
 
 .publish-modal__content ul {
   padding-left: 18px;
-  color: #334155;
+  color: var(--ne-text-muted);
 }
 
 .publish-modal__raw pre {
-  background: #0f172a;
-  color: #e2e8f0;
+  background: rgba(12, 12, 24, 0.95);
+  color: var(--ne-text);
   padding: 16px;
-  border-radius: 10px;
+  border-radius: 12px;
   max-height: 220px;
   overflow: auto;
   font-size: 0.85rem;
+  border: 1px solid rgba(255, 255, 255, 0.06);
 }
 
 @media (max-width: 640px) {

--- a/src/frontend/EventOrganizerWeb/src/styles/NewEvent/activities.css
+++ b/src/frontend/EventOrganizerWeb/src/styles/NewEvent/activities.css
@@ -1,10 +1,11 @@
 .act-wrap {
   margin-top: 32px;
-  border: 1px solid #e2e8f0;
-  border-radius: 16px;
   padding: 24px;
-  background: #ffffff;
-  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+  border-radius: 20px;
+  background: var(--ne-surface);
+  border: 1px solid var(--ne-border);
+  box-shadow: var(--ne-shadow-sm);
+  color: var(--ne-text);
 }
 
 .act-head {
@@ -12,30 +13,33 @@
   align-items: center;
   justify-content: space-between;
   margin-bottom: 18px;
+  gap: 12px;
 }
 
 .act-head h2 {
   font-size: 1.4rem;
   font-weight: 700;
-  color: #0f172a;
+  color: var(--ne-text-strong);
 }
 
 .act-badge {
   padding: 6px 12px;
   border-radius: 999px;
-  background: rgba(37, 99, 235, 0.1);
-  color: #2563eb;
+  background: var(--ne-pill-bg);
+  color: var(--ne-pill-text);
   font-weight: 600;
   font-size: 0.85rem;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow: 0 6px 16px rgba(139, 92, 246, 0.18);
 }
 
 .act-note {
-  background: #f8fafc;
-  border: 1px solid #e2e8f0;
-  border-radius: 10px;
+  background: var(--ne-note-bg);
+  border: 1px solid var(--ne-note-border);
+  border-radius: 14px;
   padding: 12px 14px;
   margin-bottom: 18px;
-  color: #475569;
+  color: var(--ne-text);
 }
 
 .act-grid {
@@ -55,7 +59,7 @@
   font-size: 1.1rem;
   font-weight: 600;
   margin-bottom: 12px;
-  color: #1e293b;
+  color: var(--ne-text-strong);
 }
 
 .act-field {
@@ -67,35 +71,35 @@
 
 .act-field span {
   font-weight: 600;
-  color: #475569;
+  color: var(--ne-text-muted);
 }
 
 .act-input,
 .act-textarea,
 .act-select {
+  background: var(--ne-input-bg);
+  border: 1px solid var(--ne-input-border);
+  color: var(--ne-text);
+  border-radius: 10px;
   padding: 10px 12px;
-  border-radius: 8px;
-  border: 1px solid #cbd5f5;
   font-size: 0.95rem;
-  background: #f8fafc;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
 }
 
 .act-input:focus,
 .act-textarea:focus,
 .act-select:focus {
   outline: none;
-  border-color: #6366f1;
-  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.15);
-  background: #fff;
+  border-color: var(--ne-input-border-focus);
+  box-shadow: var(--ne-input-shadow-focus);
 }
 
 .act-input[disabled],
 .act-textarea[disabled],
 .act-select[disabled] {
-  background: #f1f5f9;
-  color: #94a3b8;
+  opacity: 0.6;
   cursor: not-allowed;
+  background: rgba(255, 255, 255, 0.06);
 }
 
 .act-textarea {
@@ -121,45 +125,59 @@
 }
 
 .act-btn {
-  padding: 9px 16px;
-  border-radius: 8px;
-  border: none;
+  border-radius: 12px;
+  border: 1px solid transparent;
   font-weight: 600;
   cursor: pointer;
-  transition: transform 0.15s ease, box-shadow 0.15s ease;
-}
-
-.act-btn:hover:not([disabled]) {
-  transform: translateY(-1px);
-  box-shadow: 0 8px 16px rgba(37, 99, 235, 0.15);
+  padding: 10px 18px;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease, border-color 0.15s ease;
 }
 
 .act-btn:disabled {
-  opacity: 0.6;
+  opacity: 0.55;
   cursor: not-allowed;
   box-shadow: none;
-}
-
-.act-btn.act-secondary {
-  background: #e2e8f0;
-  color: #1e293b;
-}
-
-.act-btn.act-danger {
-  background: #ef4444;
-  color: #fff;
+  transform: none;
 }
 
 .act-btn:not(.act-secondary):not(.act-danger) {
-  background: #2563eb;
+  background: var(--ne-btn-primary);
+  color: #fff;
+  box-shadow: 0 10px 28px rgba(139, 92, 246, 0.35);
+}
+
+.act-btn:not(.act-secondary):not(.act-danger):not(:disabled):hover {
+  background: var(--ne-btn-primary-hover);
+  transform: translateY(-1px);
+}
+
+.act-btn.act-secondary {
+  background: var(--ne-btn-secondary);
+  border-color: var(--ne-border-strong);
+  color: var(--ne-text);
+}
+
+.act-btn.act-secondary:not(:disabled):hover {
+  background: var(--ne-btn-secondary-hover);
+  transform: translateY(-1px);
+}
+
+.act-btn.act-danger {
+  background: var(--ne-btn-danger);
   color: #fff;
 }
 
+.act-btn.act-danger:not(:disabled):hover {
+  background: var(--ne-btn-danger-hover);
+  transform: translateY(-1px);
+}
+
 .act-schedule {
-  background: #f8fafc;
-  border-radius: 12px;
-  border: 1px solid #e2e8f0;
+  background: var(--ne-surface-alt);
+  border-radius: 16px;
+  border: 1px solid var(--ne-border);
   padding: 18px;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
 }
 
 .act-table {
@@ -172,15 +190,19 @@
   padding: 10px 12px;
   text-align: left;
   font-size: 0.92rem;
-  color: #1e293b;
+  color: var(--ne-text);
 }
 
 .act-table thead {
-  background: #e2e8f0;
+  background: var(--ne-table-head);
 }
 
 .act-table tbody tr:nth-child(even) {
-  background: #edf2f7;
+  background: var(--ne-table-row-alt);
+}
+
+.act-table tbody tr:hover {
+  background: rgba(139, 92, 246, 0.08);
 }
 
 .act-cell-main {
@@ -189,7 +211,7 @@
 
 .act-cell-sub {
   font-size: 0.8rem;
-  color: #64748b;
+  color: var(--ne-text-muted);
 }
 
 .act-row-actions {
@@ -199,6 +221,6 @@
 
 .act-empty {
   text-align: center;
-  padding: 16px;
-  color: #64748b;
+  padding: 18px;
+  color: var(--ne-text-muted);
 }

--- a/src/frontend/EventOrganizerWeb/src/styles/NewEvent/areas.css
+++ b/src/frontend/EventOrganizerWeb/src/styles/NewEvent/areas.css
@@ -1,36 +1,223 @@
 /* src/styles/NewEvent/areas.css */
-.ar-wrap { margin-top: 24px; }
-.ar-head { display:flex; align-items:center; gap:12px; }
-.ar-title { font-weight:700; font-size:18px; }
-.ar-spacer { flex:1; }
-.ar-btn { padding:8px 12px; border:1px solid #444; border-radius:8px; background:#111; color:#eee; cursor:pointer; }
-.ar-btn:disabled { opacity:.5; cursor:not-allowed; }
-.ar-note { padding:12px; background:#1a1a1a; border:1px dashed #333; border-radius:10px; margin-top:10px; color:#bbb; }
+.ar-wrap {
+  margin-top: 32px;
+}
 
-.ar-list { display:grid; gap:14px; margin-top:16px; }
+.ar-head {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
 
-.ar-card { border:1px solid #333; border-radius:12px; background:#0f0f0f; padding:14px; }
-.ar-card.locked { opacity:.92; }
-.ar-card-head { display:flex; align-items:center; gap:10px; }
-.ar-card-title { font-weight:600; }
-.ar-actions { margin-left:auto; display:flex; gap:8px; }
+.ar-title {
+  font-weight: 700;
+  font-size: 1.2rem;
+  color: var(--ne-text-strong);
+}
 
-.ar-grid { display:grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap:12px; margin-top:12px; }
-@media (max-width: 1000px) { .ar-grid { grid-template-columns: 1fr; } }
+.ar-spacer {
+  flex: 1;
+}
 
-.label { font-size:12px; color:#aaa; margin-bottom:6px; }
-.input, .select { width:100%; padding:8px 10px; border:1px solid #333; background:#111; color:#eee; border-radius:8px; }
-.color-row { display:flex; align-items:center; gap:10px; }
-.color-swatch { width:20px; height:20px; border-radius:4px; border:1px solid #333; }
+.ar-btn {
+  padding: 10px 16px;
+  border: 1px solid var(--ne-border-strong);
+  border-radius: 12px;
+  background: var(--ne-btn-secondary);
+  color: var(--ne-text);
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.15s ease, background 0.15s ease, border-color 0.15s ease;
+}
 
-.map-toggle { margin-top:8px; display:flex; gap:8px; }
-.map-wrap { margin-top:12px; border:1px solid #333; border-radius:12px; padding:10px; background:#0c0c0c; }
+.ar-btn:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+  transform: none;
+}
 
-.map-toolbar { display:flex; gap:8px; margin-bottom:8px; }
-.map-canvas { width:100%; height:360px; background:repeating-linear-gradient(45deg,#121212,#121212 10px,#141414 10px,#141414 20px); border-radius:10px; position:relative; overflow:hidden; }
+.ar-btn:not(:disabled):hover {
+  background: var(--ne-btn-secondary-hover);
+  transform: translateY(-1px);
+}
 
-svg.map-svg { width:100%; height:100%; display:block; }
-.map-pin { stroke:#3b82f6; fill:#3b82f6; }
-.map-poly { stroke:#888; stroke-width:2; fill-opacity:.35; }
-.map-poly-existing { fill-opacity:.25; pointer-events:auto; } /* blokira klik unutar postojećeg poligona */
-.map-label { font-size:12px; fill:#ddd; text-shadow: 0 1px 1px #000; }
+.ar-note {
+  padding: 12px 14px;
+  background: var(--ne-note-bg);
+  border: 1px solid var(--ne-note-border);
+  border-radius: 14px;
+  margin-top: 12px;
+  color: var(--ne-text);
+}
+
+.ar-list {
+  display: grid;
+  gap: 16px;
+  margin-top: 18px;
+}
+
+.ar-card {
+  border: 1px solid var(--ne-border);
+  border-radius: 18px;
+  background: var(--ne-surface-alt);
+  padding: 16px;
+  box-shadow: var(--ne-shadow-sm);
+  transition: border-color 0.15s ease, transform 0.12s ease, box-shadow 0.15s ease;
+}
+
+.ar-card:hover {
+  border-color: var(--ne-border-strong);
+  transform: translateY(-1px);
+  box-shadow: var(--ne-shadow-md);
+}
+
+.ar-card.locked {
+  opacity: 0.9;
+}
+
+.ar-card-head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.ar-card-title {
+  font-weight: 600;
+  color: var(--ne-text-strong);
+}
+
+.ar-actions {
+  margin-left: auto;
+  display: flex;
+  gap: 8px;
+}
+
+.ar-actions .btn {
+  border-radius: 12px;
+  padding: 8px 14px;
+  border: 1px solid var(--ne-border-strong);
+  background: var(--ne-btn-secondary);
+  color: var(--ne-text);
+  font-weight: 600;
+  transition: transform 0.15s ease, background 0.15s ease, border-color 0.15s ease;
+}
+
+.ar-actions .btn:not(:disabled):hover {
+  background: var(--ne-btn-secondary-hover);
+  transform: translateY(-1px);
+}
+
+.ar-actions .btn:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.ar-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 14px;
+  margin-top: 14px;
+}
+
+@media (max-width: 1000px) {
+  .ar-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.ar-card .label {
+  font-size: 0.8rem;
+  color: var(--ne-text-muted);
+  margin-bottom: 6px;
+}
+
+.ar-card .input,
+.ar-card .select {
+  width: 100%;
+  padding: 10px 12px;
+  border: 1px solid var(--ne-input-border);
+  background: var(--ne-input-bg);
+  color: var(--ne-text);
+  border-radius: 10px;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
+}
+
+.ar-card .input:focus,
+.ar-card .select:focus {
+  outline: none;
+  border-color: var(--ne-input-border-focus);
+  box-shadow: var(--ne-input-shadow-focus);
+}
+
+.color-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.color-swatch {
+  width: 22px;
+  height: 22px;
+  border-radius: 6px;
+  border: 1px solid var(--ne-border-strong);
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.3);
+}
+
+.map-toggle {
+  margin-top: 10px;
+  display: flex;
+  gap: 8px;
+}
+
+.map-wrap {
+  margin-top: 14px;
+  border: 1px solid var(--ne-border);
+  border-radius: 16px;
+  padding: 12px;
+  background: var(--ne-surface);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
+}
+
+.map-toolbar {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+
+.map-canvas {
+  width: 100%;
+  height: 360px;
+  background: repeating-linear-gradient(45deg, #121212, #121212 10px, #141414 10px, #141414 20px);
+  border-radius: 12px;
+  position: relative;
+  overflow: hidden;
+}
+
+svg.map-svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.map-pin {
+  stroke: #8b5cf6;
+  fill: #8b5cf6;
+}
+
+.map-poly {
+  stroke: rgba(255, 255, 255, 0.45);
+  stroke-width: 2;
+  fill-opacity: 0.35;
+}
+
+.map-poly-existing {
+  fill-opacity: 0.25;
+  pointer-events: auto;
+}
+
+.map-label {
+  font-size: 12px;
+  fill: var(--ne-text);
+  text-shadow: 0 1px 1px #000;
+}

--- a/src/frontend/EventOrganizerWeb/src/styles/NewEvent/basicinfo.css
+++ b/src/frontend/EventOrganizerWeb/src/styles/NewEvent/basicinfo.css
@@ -1,93 +1,96 @@
 /* src/styles/NewEvent/basicinfo.css */
 
-/* --- postojeći ne-* blok (ostavljen) --- */
-.ne-container{max-width:960px;margin:0 auto;padding:24px;}
-.ne-title{font-size:24px;font-weight:600;margin-bottom:8px;}
-.ne-subtitle{opacity:.8;margin-bottom:16px;}
-.ne-section{background:rgba(255,255,255,0.04);border:1px solid rgba(255,255,255,0.1);border-radius:12px;padding:16px;margin-bottom:16px;}
-.ne-grid{display:grid;grid-template-columns:1fr 1fr;gap:12px;}
-.ne-col-span-2{grid-column:span 2;}
-.ne-field{display:flex;flex-direction:column;gap:6px;}
-.ne-label{font-size:14px;opacity:.85;}
-.ne-input{padding:10px 12px;border:1px solid rgba(255,255,255,0.18);border-radius:8px;background:rgba(255,255,255,0.03);color:inherit;outline:none;}
-.ne-input:focus{border-color:#5aa9ff;box-shadow:0 0 0 2px rgba(90,169,255,.25)}
-.ne-inline{display:flex;align-items:center;gap:10px;}
-.ne-check{display:flex;align-items:center;gap:6px;font-size:14px;opacity:.85;}
-.ne-rt-toolbar{display:flex;gap:6px;margin-bottom:8px;}
-.ne-rt-toolbar button{border:1px solid rgba(255,255,255,0.18);background:rgba(255,255,255,0.05);border-radius:8px;padding:6px 10px;cursor:pointer}
-.ne-rt-toolbar button:hover{background:rgba(255,255,255,0.08)}
-.ne-rt-editor{min-height:140px;border:1px dashed rgba(255,255,255,0.25);border-radius:10px;padding:10px;background:rgba(255,255,255,0.02);}
-.ne-rt-editor:empty:before{content:attr(data-placeholder);opacity:.4}
-.ne-upload{display:flex;gap:10px;align-items:center;margin-top:8px;}
-.ne-btn{border:1px solid rgba(255,255,255,0.18);padding:8px 12px;border-radius:8px;background:rgba(255,255,255,0.06);cursor:pointer}
-.ne-btn:disabled{opacity:.6;cursor:not-allowed}
-.ne-preview{margin-top:12px;}
-.ne-preview img{max-width:100%;height:auto;border-radius:10px;border:1px solid rgba(255,255,255,0.15)}
-.ne-alert{padding:10px 12px;border-radius:8px;margin-top:12px;}
-.ne-alert-error{background:rgba(255,0,0,0.08);border:1px solid rgba(255,0,0,0.25)}
-@media (max-width:800px){
-  .ne-grid{grid-template-columns:1fr;}
-  .ne-col-span-2{grid-column:span 1;}
+.rt-toolbar {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-bottom: 10px;
 }
 
-/* --- dodatno za NOVI BasicInfo.jsx --- */
-.rt-toolbar{display:flex;gap:6px;margin-bottom:8px;}
-.rt-toolbar button{border:1px solid rgba(255,255,255,0.18);background:rgba(255,255,255,0.05);border-radius:8px;padding:6px 10px;cursor:pointer}
-.rt-toolbar button:hover{background:rgba(255,255,255,0.08)}
-.rt-toolbar button.active{outline:2px solid rgba(90,169,255,.6);background:rgba(255,255,255,0.12)}
-.rt-editor{min-height:140px;border:1px dashed rgba(255,255,255,0.25);border-radius:10px;padding:10px;background:rgba(255,255,255,0.02);}
-.rt-editor:empty::before{content:attr(data-placeholder);opacity:.5}
-.img-thumb{width:240px;height:150px;object-fit:cover;border-radius:10px;border:1px solid rgba(255,255,255,0.15)}
+.rt-toolbar button {
+  border: 1px solid var(--ne-border-strong);
+  background: var(--ne-btn-secondary);
+  color: var(--ne-text);
+  border-radius: 10px;
+  padding: 6px 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease, transform 0.12s ease;
+}
 
+.rt-toolbar button:hover {
+  background: var(--ne-btn-secondary-hover);
+  transform: translateY(-1px);
+}
 
+.rt-toolbar button.active {
+  border-color: var(--ne-btn-primary);
+  background: rgba(139, 92, 246, 0.25);
+  box-shadow: 0 0 0 2px rgba(139, 92, 246, 0.2);
+}
 
-/* Scoped hidden input so it doesn't nuke Tailwind's .hidden */
-.bi-file{display:none;}
-/* --- Upload dugme (lokalno za BasicInfo) --- */
-.bi-upload-btn{
+.rt-editor {
+  min-height: 160px;
+  border: 1px dashed rgba(139, 92, 246, 0.35);
+  border-radius: 14px;
+  padding: 12px;
+  background: rgba(24, 24, 39, 0.85);
+  color: var(--ne-text);
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.rt-editor:focus {
+  outline: none;
+  border-color: var(--ne-input-border-focus);
+  box-shadow: var(--ne-input-shadow-focus);
+}
+
+.rt-editor:empty::before {
+  content: attr(data-placeholder);
+  opacity: 0.45;
+  color: var(--ne-text-muted);
+}
+
+.img-thumb {
+  width: 240px;
+  height: 150px;
+  object-fit: cover;
+  border-radius: 14px;
+  border: 1px solid var(--ne-border-strong);
+  background: rgba(0, 0, 0, 0.2);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
+}
+
+.bi-file {
+  display: none;
+}
+
+.bi-upload-btn {
   min-width: 160px;
-  border: 1px solid rgba(255,255,255,0.18);
-  border-radius: 8px;
-  padding: 8px 12px;
-  background: rgba(255,255,255,0.06);
+  border: 1px solid var(--ne-border-strong);
+  border-radius: 12px;
+  padding: 10px 16px;
+  background: var(--ne-btn-secondary);
+  color: var(--ne-text);
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.15s ease, background 0.15s ease, border-color 0.15s ease;
 }
 
-.bi-upload-btn:hover{
-  background: rgba(255,255,255,0.10);
-  border-color: rgba(255,255,255,0.25);
+.bi-upload-btn:hover {
+  background: var(--ne-btn-secondary-hover);
+  transform: translateY(-1px);
 }
 
-.bi-upload-btn:disabled{
-  opacity: .6;
+.bi-upload-btn:disabled {
+  opacity: 0.55;
   cursor: not-allowed;
+  transform: none;
 }
 
-
-
-/* Disabled look for capacity when 'beskonačno' */
-.bi-capacity:disabled{
-  opacity:.6;
-  cursor:not-allowed;
-  background: rgba(255,255,255,0.06);
+.bi-capacity:disabled,
+.input:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  background: rgba(255, 255, 255, 0.06);
 }
-
-/* Disabled input */
-.input:disabled{
-  opacity:.6;
-  cursor:not-allowed;
-  background: rgba(255,255,255,0.06);
-}
-
-.bi-file{display:none;}
-.bi-upload-btn{
-  min-width:160px;
-  border:1px solid rgba(255,255,255,0.18);
-  border-radius:8px;
-  padding:8px 12px;
-  background:rgba(255,255,255,0.06);
-}
-.bi-upload-btn:hover{
-  background:rgba(255,255,255,0.10);
-  border-color:rgba(255,255,255,0.25);
-}
-.bi-upload-btn:disabled{opacity:.6;cursor:not-allowed;}

--- a/src/frontend/EventOrganizerWeb/src/styles/NewEvent/days.css
+++ b/src/frontend/EventOrganizerWeb/src/styles/NewEvent/days.css
@@ -1,86 +1,160 @@
 /* src/styles/NewEvent/days.css */
 
 /* Wrapper i header (u skladu sa tickets.css/basicinfo.css) */
-.dy-wrap{margin: 5% 0%;}
-.dy-head{display:flex;align-items:center;gap:12px;margin-bottom:12px;}
-.dy-btn{
-  border:1px solid rgba(255,255,255,0.18);
-  border-radius:8px;
-  padding:8px 12px;
-  background:rgba(255,255,255,0.06);
-  cursor:pointer;
+.dy-wrap {
+  margin-top: 32px;
 }
-.dy-btn:disabled{opacity:.6;cursor:not-allowed;}
-.dy-btn:hover{background:rgba(255,255,255,0.10);border-color:rgba(255,255,255,0.25);}
+
+.dy-head {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.dy-title {
+  font-size: 1.3rem;
+  font-weight: 600;
+  color: var(--ne-text-strong);
+}
+
+.dy-btn {
+  border: 1px solid var(--ne-border-strong);
+  border-radius: 12px;
+  padding: 10px 16px;
+  background: var(--ne-btn-secondary);
+  color: var(--ne-text);
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.15s ease, background 0.15s ease, border-color 0.15s ease;
+}
+
+.dy-btn:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.dy-btn:not(:disabled):hover {
+  background: var(--ne-btn-secondary-hover);
+  transform: translateY(-1px);
+}
 
 /* Info poruka */
-.dy-note{margin-bottom:10px; opacity:.85}
+.dy-note {
+  margin-bottom: 12px;
+  padding: 10px 12px;
+  border-radius: 14px;
+  background: var(--ne-note-bg);
+  border: 1px solid var(--ne-note-border);
+  color: var(--ne-text);
+}
 
 /* Lista i kartice */
-.dy-list{display:flex;flex-direction:column;gap:12px;}
-.dy-card{border:1px solid rgba(255,255,255,0.12);border-radius:12px;padding:12px;background:rgba(255,255,255,0.04);}
+.dy-main {
+  border: 1px solid var(--ne-border);
+  border-radius: 20px;
+  padding: 18px;
+  background: var(--ne-surface);
+  box-shadow: var(--ne-shadow-sm);
+}
+
+.dy-list {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.dy-card {
+  border: 1px solid var(--ne-border);
+  border-radius: 16px;
+  background: var(--ne-surface-alt);
+  overflow: hidden;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease, transform 0.12s ease;
+}
+
+.dy-card:hover {
+  border-color: var(--ne-border-strong);
+  box-shadow: var(--ne-shadow-md);
+  transform: translateY(-1px);
+}
 
 /* Grid za polja (preslikano iz tickets.css col-grid) */
-.dy-grid{display:grid;grid-template-columns:repeat(3, minmax(0,1fr)); gap:12px}
-@media (max-width: 1024px){
-  .dy-grid{grid-template-columns:repeat(2,minmax(0,1fr));}
-}
-@media (max-width: 640px){
-  .dy-grid{grid-template-columns:1fr;}
-}
-
-/* Disabled input look (isti kao basicinfo.css) */
-.input:disabled{
-  opacity:.6;
-  cursor:not-allowed;
-  background: rgba(255,255,255,0.06);
-}
-/* Glavna “podforma” (okvir oko cele liste dana) */
-.dy-main{
-  border:1px solid rgba(255,255,255,0.12);
-  border-radius:16px;
-  padding:16px;
-  background:rgba(255,255,255,0.03);
-  box-shadow:0 6px 20px rgba(0,0,0,0.25);
+.dy-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+  padding: 12px 14px 16px;
 }
 
-/* Doterivanje kartice jednog dana */
-.dy-card{
-  border-radius:14px;
-  padding:0;               /* header + body imaju svoje padding-e */
-  overflow:hidden;
-  transition:border-color .15s ease, box-shadow .15s ease, transform .12s ease;
+@media (max-width: 1024px) {
+  .dy-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
 }
-.dy-card:hover{
-  border-color:rgba(255,255,255,0.18);
-  box-shadow:0 8px 26px rgba(0,0,0,0.28);
-  transform:translateY(-1px);
+
+@media (max-width: 640px) {
+  .dy-grid {
+    grid-template-columns: 1fr;
+  }
 }
 
 /* Header kartice (dan + datum + dugme) */
-.dy-card-head{
-  display:flex; align-items:center; gap:10px;
-  padding:10px 12px;
-  background:rgba(255,255,255,0.04);
+.dy-card-head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 14px;
+  background: var(--ne-surface-soft);
 }
-.dy-title{ font-weight:600; }
-.dy-badge{
-  font-size:12px; opacity:.9;
-  border:1px solid rgba(255,255,255,0.15);
-  border-radius:999px; padding:4px 8px;
+
+.dy-badge {
+  font-size: 12px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  color: var(--ne-text);
+  background: rgba(139, 92, 246, 0.18);
 }
-.dy-spacer{ flex:1; }
+
+.dy-spacer {
+  flex: 1;
+}
 
 /* Separator između headera i tela */
-.dy-sep{ height:1px; background:rgba(255,255,255,0.10); }
+.dy-sep {
+  height: 1px;
+  background: rgba(255, 255, 255, 0.12);
+}
 
-/* Unutrašnji padding grida u telu kartice */
-.dy-grid{ padding:12px; }
+/* Dugme poravnaj u headeru */
+.dy-actions {
+  display: flex;
+  align-items: center;
+}
 
-/* Dugme poravnaј u headeru */
-.dy-actions{ display:flex; align-items:center; }
+.dy-actions .btn {
+  border-radius: 12px;
+  padding: 8px 14px;
+  background: var(--ne-btn-secondary);
+  border: 1px solid var(--ne-border-strong);
+  color: var(--ne-text);
+  font-weight: 600;
+  transition: transform 0.15s ease, background 0.15s ease, border-color 0.15s ease;
+}
+
+.dy-actions .btn:not(:disabled):hover {
+  background: var(--ne-btn-secondary-hover);
+  transform: translateY(-1px);
+}
+
+.dy-actions .btn:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+  transform: none;
+}
 
 /* Zaključano stanje – suptilno priguši inputs */
-.dy-card.is-locked .input{
-  opacity:.75;
+.dy-card.is-locked .input {
+  opacity: 0.75;
 }

--- a/src/frontend/EventOrganizerWeb/src/styles/NewEvent/locations.css
+++ b/src/frontend/EventOrganizerWeb/src/styles/NewEvent/locations.css
@@ -1,71 +1,182 @@
 /* src/styles/NewEvent/locations.css */
 
-/* Uvozimo izgled iz areas.css (:contentReference[oaicite:6]{index=6}) – ovde dodajemo samo specifičnosti za pin i resurse */
-.loc-pin { stroke:#111; fill:#fff; opacity:.9; }
-.loc-pin-label { font-size:10px; fill:#eee; text-shadow: 0 1px 1px #000; }
+/* Uvozimo izgled iz areas.css – ovde dodajemo specifičnosti za pin i resurse */
+.loc-pin {
+  stroke: #8b5cf6;
+  fill: #8b5cf6;
+  opacity: 0.9;
+}
+
+.loc-pin-label {
+  font-size: 10px;
+  fill: var(--ne-text);
+  text-shadow: 0 1px 1px #000;
+}
 
 .loc-res-wrap {
   display: grid;
   grid-template-columns: 7fr 3fr;
-  gap: 12px;
-  margin-top: 16px;
-}
-@media (max-width: 1100px){
-  .loc-res-wrap { grid-template-columns: 1fr; }
+  gap: 16px;
+  margin-top: 18px;
 }
 
-.loc-res-table {
-  border:1px solid #333; border-radius:12px; background:#0f0f0f; padding:12px;
+@media (max-width: 1100px) {
+  .loc-res-wrap {
+    grid-template-columns: 1fr;
+  }
 }
 
-.loc-table { width:100%; border-collapse: collapse; }
-.loc-table th, .loc-table td { border-bottom:1px solid #222; padding:8px; }
-.loc-table th { text-align:left; color:#bbb; font-weight:600; }
-.loc-table td { color:#ddd; }
-
+.loc-res-table,
 .loc-res-form {
-  border:1px solid #333; border-radius:12px; background:#0f0f0f; padding:12px;
+  border: 1px solid var(--ne-border);
+  border-radius: 18px;
+  background: var(--ne-surface-alt);
+  padding: 16px;
+  box-shadow: var(--ne-shadow-sm);
+}
+
+.loc-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.loc-table th,
+.loc-table td {
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  padding: 10px 12px;
+  color: var(--ne-text);
+}
+
+.loc-table th {
+  text-align: left;
+  color: var(--ne-text-muted);
+  font-weight: 600;
+}
+
+.loc-table tbody tr:nth-child(even) {
+  background: var(--ne-table-row-alt);
+}
+
+.loc-table tbody tr:hover {
+  background: rgba(139, 92, 246, 0.08);
+}
+
+.loc-table th,
+.loc-table td {
+  vertical-align: middle;
+}
+
+.loc-table th.num,
+.loc-table td.num {
+  text-align: right;
+  width: 100px;
+}
+
+.loc-table .center {
+  text-align: center;
+}
+
+.loc-table .muted {
+  color: var(--ne-text-muted);
+}
+
+.loc-res-table .label {
+  margin-bottom: 8px;
+  display: block;
+  color: var(--ne-text-muted);
+}
+
+.loc-res-form .input,
+.loc-res-form .select,
+.loc-res-form .textarea {
+  background: var(--ne-input-bg);
+  border: 1px solid var(--ne-input-border);
+  color: var(--ne-text);
+  border-radius: 10px;
+  padding: 10px 12px;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.loc-res-form .input:focus,
+.loc-res-form .select:focus,
+.loc-res-form .textarea:focus {
+  outline: none;
+  border-color: var(--ne-input-border-focus);
+  box-shadow: var(--ne-input-shadow-focus);
 }
 
 /* Pin (divIcon) */
-.pin-divicon { pointer-events: none; } /* klik ide na mapu, ne na HTML ikonu */
-.pin-wrap { position: relative; transform: translate(-50%, -100%); }
+.pin-divicon {
+  pointer-events: none;
+}
+
+.pin-wrap {
+  position: relative;
+  transform: translate(-50%, -100%);
+}
+
 .pin-label {
   position: relative;
-  left: 50%; transform: translateX(-50%);
-  padding: 2px 6px; border-radius: 4px;
-  color: #111; font-size: 12px; font-weight: 600;
-  box-shadow: 0 1px 2px rgba(0,0,0,.4);
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 2px 6px;
+  border-radius: 4px;
+  color: #111;
+  font-size: 12px;
+  font-weight: 600;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.4);
   white-space: nowrap;
 }
+
 .pin-tail {
   position: relative;
-  left: 50%; transform: translateX(-50%);
-  width: 0; height: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 0;
+  height: 0;
   border-left: 6px solid transparent;
   border-right: 6px solid transparent;
-  border-top: 8px solid #8888ff; /* boja se prepisuje inline-om */
+  border-top: 8px solid #8b5cf6;
 }
-.map-canvas { height: 420px; }
 
-/* ----- Tabela finese ----- */
-.loc-table th, .loc-table td { vertical-align: middle; }
-.loc-table th.num, .loc-table td.num { text-align: right; width: 100px; }
-.loc-table .center { text-align: center; }
-.loc-table .muted { color: #999; }
-.loc-res-table .label { margin-bottom: 8px; display: block; }
+.map-canvas {
+  height: 420px;
+}
 
 /* ----- Modal za opis ----- */
 .modal-backdrop {
-  position: fixed; inset: 0; background: rgba(0,0,0,.55);
-  display: flex; align-items: center; justify-content: center; z-index: 50;
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 50;
 }
+
 .modal {
-  background: #0f0f0f; border: 1px solid #333; border-radius: 12px; width: min(640px, 92vw);
-  box-shadow: 0 10px 30px rgba(0,0,0,.45); padding: 12px;
+  background: var(--ne-surface);
+  border: 1px solid var(--ne-border);
+  border-radius: 16px;
+  width: min(640px, 92vw);
+  box-shadow: var(--ne-shadow-md);
+  padding: 18px;
 }
+
 .modal-head {
-  display: flex; align-items: center; gap: 12px; margin-bottom: 8px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 10px;
 }
-.modal-title { font-weight: 700; }
-.modal-body { color: #ddd; line-height: 1.5; white-space: pre-wrap; }
+
+.modal-title {
+  font-weight: 700;
+  color: var(--ne-text-strong);
+}
+
+.modal-body {
+  color: var(--ne-text);
+  line-height: 1.5;
+  white-space: pre-wrap;
+}

--- a/src/frontend/EventOrganizerWeb/src/styles/NewEvent/pricelist.css
+++ b/src/frontend/EventOrganizerWeb/src/styles/NewEvent/pricelist.css
@@ -2,34 +2,54 @@
 
 .pl-section {
   margin-top: 32px;
-  border: 1px solid #e5e7eb;
-  border-radius: 12px;
+  border: 1px solid var(--ne-border);
+  border-radius: 20px;
   padding: 24px;
-  background: #ffffff;
-  box-shadow: 0 8px 20px rgba(15, 23, 42, 0.06);
+  background: var(--ne-surface);
+  box-shadow: var(--ne-shadow-sm);
+  color: var(--ne-text);
 }
 
 .pl-header {
   display: flex;
   align-items: center;
   gap: 16px;
-  margin-bottom: 18px;
+  margin-bottom: 20px;
 }
 
 .pl-header h2 {
   font-size: 1.4rem;
   font-weight: 700;
-  color: #0f172a;
+  color: var(--ne-text-strong);
 }
 
 .pl-header .pl-subtitle {
   margin-left: auto;
   font-size: 0.95rem;
-  color: #64748b;
+  color: var(--ne-text-muted);
 }
 
 .pl-header .pl-btn-inline {
   margin-left: auto;
+}
+
+.pl-topbar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 18px;
+}
+
+.pl-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: var(--ne-pill-bg);
+  color: var(--ne-pill-text);
+  font-weight: 600;
+  font-size: 0.85rem;
+  border: 1px solid rgba(255, 255, 255, 0.12);
 }
 
 .pl-meta {
@@ -37,7 +57,7 @@
   gap: 16px;
   align-items: flex-end;
   flex-wrap: wrap;
-  margin-bottom: 18px;
+  margin-bottom: 20px;
 }
 
 .pl-meta .pl-field {
@@ -50,35 +70,35 @@
 .pl-meta label {
   font-size: 0.9rem;
   font-weight: 600;
-  color: #475569;
+  color: var(--ne-text-muted);
 }
 
 .pl-input,
 .pl-select,
 .pl-textarea {
   padding: 10px 12px;
-  border-radius: 8px;
-  border: 1px solid #cbd5f5;
+  border-radius: 10px;
+  border: 1px solid var(--ne-input-border);
   font-size: 0.95rem;
-  background: #f8fafc;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  background: var(--ne-input-bg);
+  color: var(--ne-text);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
 }
 
 .pl-input:focus,
 .pl-select:focus,
 .pl-textarea:focus {
   outline: none;
-  border-color: #6366f1;
-  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.15);
-  background: #fff;
+  border-color: var(--ne-input-border-focus);
+  box-shadow: var(--ne-input-shadow-focus);
 }
 
 .pl-input[disabled],
 .pl-select[disabled],
 .pl-textarea[disabled] {
-  background: #f1f5f9;
-  color: #94a3b8;
+  opacity: 0.6;
   cursor: not-allowed;
+  background: rgba(255, 255, 255, 0.06);
 }
 
 .pl-controls {
@@ -89,33 +109,44 @@
 
 .pl-btn {
   padding: 10px 18px;
-  border-radius: 8px;
-  border: none;
-  background: #2563eb;
+  border-radius: 12px;
+  border: 1px solid transparent;
+  background: var(--ne-btn-primary);
   color: #fff;
   font-weight: 600;
   cursor: pointer;
-  transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease, border-color 0.15s ease;
 }
 
 .pl-btn:hover:not([disabled]) {
   transform: translateY(-1px);
-  box-shadow: 0 8px 16px rgba(37, 99, 235, 0.2);
+  background: var(--ne-btn-primary-hover);
+  box-shadow: 0 10px 28px rgba(139, 92, 246, 0.35);
 }
 
 .pl-btn:disabled {
-  opacity: 0.6;
+  opacity: 0.55;
   cursor: not-allowed;
   box-shadow: none;
+  transform: none;
 }
 
 .pl-btn.pl-secondary {
-  background: #e2e8f0;
-  color: #1e293b;
+  background: var(--ne-btn-secondary);
+  border-color: var(--ne-border-strong);
+  color: var(--ne-text);
+}
+
+.pl-btn.pl-secondary:hover:not([disabled]) {
+  background: var(--ne-btn-secondary-hover);
 }
 
 .pl-btn.pl-danger {
-  background: #ef4444;
+  background: var(--ne-btn-danger);
+}
+
+.pl-btn.pl-danger:hover:not([disabled]) {
+  background: var(--ne-btn-danger-hover);
 }
 
 .pl-content {
@@ -131,16 +162,16 @@
 
 .pl-form-wrap {
   flex: 2;
-  min-width: 240px;
+  min-width: 260px;
 }
 
 .pl-table {
   width: 100%;
   border-collapse: collapse;
-  border-radius: 10px;
+  border-radius: 14px;
   overflow: hidden;
-  background: #f8fafc;
-  box-shadow: inset 0 0 0 1px #e2e8f0;
+  background: var(--ne-surface-alt);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
 }
 
 .pl-table th,
@@ -148,86 +179,93 @@
   padding: 12px 14px;
   text-align: left;
   font-size: 0.95rem;
-  color: #1e293b;
+  color: var(--ne-text);
 }
 
 .pl-table thead {
-  background: #e2e8f0;
+  background: var(--ne-table-head);
 }
 
 .pl-table tbody tr:nth-child(even) {
-  background: #f1f5f9;
+  background: var(--ne-table-row-alt);
 }
 
 .pl-table tbody tr:hover {
-  background: #e0f2fe;
+  background: rgba(139, 92, 246, 0.08);
 }
 
 .pl-empty {
   text-align: center;
   padding: 24px;
   font-size: 0.95rem;
-  color: #64748b;
+  color: var(--ne-text-muted);
 }
 
 .pl-item-form {
   display: flex;
   flex-direction: column;
   gap: 12px;
-  padding: 16px;
-  border: 1px dashed #cbd5f5;
-  border-radius: 10px;
-  background: #f8fafc;
+  padding: 18px;
+  border: 1px dashed rgba(139, 92, 246, 0.35);
+  border-radius: 14px;
+  background: var(--ne-surface-alt);
 }
 
 .pl-item-form h3 {
   margin: 0;
   font-size: 1.1rem;
   font-weight: 600;
-  color: #1e293b;
+  color: var(--ne-text-strong);
 }
 
 .pl-row-actions {
   display: flex;
-  gap: 8px;
+  gap: 10px;
+}
+
+.pl-row-actions .pl-btn {
+  padding: 8px 14px;
 }
 
 .pl-pill {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  padding: 4px 8px;
+  padding: 4px 10px;
   border-radius: 999px;
+  background: rgba(139, 92, 246, 0.18);
+  color: var(--ne-text);
   font-size: 0.75rem;
   font-weight: 600;
-  background: #ede9fe;
-  color: #6d28d9;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
 }
 
 .pl-select-existing {
   min-width: 240px;
-  padding: 8px 12px;
-  border-radius: 8px;
-  border: 1px solid #cbd5f5;
-  background: #f8fafc;
+  padding: 9px 12px;
+  border-radius: 12px;
+  border: 1px solid var(--ne-input-border);
+  background: var(--ne-input-bg);
+  color: var(--ne-text);
   font-size: 0.95rem;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
 }
 
 .pl-select-existing:focus {
   outline: none;
-  border-color: #6366f1;
-  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.15);
-  background: #fff;
+  border-color: var(--ne-input-border-focus);
+  box-shadow: var(--ne-input-shadow-focus);
 }
 
 .pl-message {
   margin-top: 18px;
   font-size: 0.95rem;
-  color: #475569;
+  color: var(--ne-text-muted);
 }
 
 .pl-message strong {
-  color: #0f172a;
+  color: var(--ne-text-strong);
 }
 
 .pl-item-grid {
@@ -237,37 +275,21 @@
 }
 
 .pl-file {
-  padding: 8px 12px;
-  border-radius: 8px;
-  border: 1px dashed #cbd5f5;
-  background: #fff;
+  padding: 10px 12px;
+  border-radius: 12px;
+  border: 1px dashed rgba(139, 92, 246, 0.35);
+  background: rgba(24, 24, 39, 0.7);
   font-size: 0.9rem;
+  color: var(--ne-text-muted);
 }
 
 .pl-hint {
   font-size: 0.8rem;
-  color: #94a3b8;
-}
-
-.pl-topbar {
-  display: flex;
-  align-items: center;
-  gap: 16px;
-  flex-wrap: wrap;
-  margin-bottom: 12px;
-}
-
-.pl-topbar .pl-badge {
-  padding: 4px 10px;
-  border-radius: 999px;
-  font-size: 0.75rem;
-  font-weight: 600;
-  background: #dbeafe;
-  color: #1d4ed8;
+  color: var(--ne-text-muted);
 }
 
 .pl-divider {
   height: 1px;
-  background: #e2e8f0;
+  background: rgba(255, 255, 255, 0.08);
   margin: 18px 0;
 }

--- a/src/frontend/EventOrganizerWeb/src/styles/NewEvent/tickets.css
+++ b/src/frontend/EventOrganizerWeb/src/styles/NewEvent/tickets.css
@@ -1,33 +1,170 @@
 /* src/styles/NewEvent/tickets.css */
 
 /* Wrapper i header */
-.tk-wrap{margin: 5% 0%;}
-.tk-head{display:flex;align-items:center;gap:12px;margin-bottom:12px;}
-.tk-add{}
+.tk-wrap {
+  margin-top: 32px;
+}
+
+.tk-head {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.tk-head h2 {
+  font-size: 1.3rem;
+  font-weight: 600;
+  color: var(--ne-text-strong);
+}
+
+.btn.tk-add {
+  background: var(--ne-btn-primary);
+  border: 1px solid transparent;
+  border-radius: 12px;
+  padding: 10px 18px;
+  box-shadow: 0 10px 28px rgba(139, 92, 246, 0.35);
+  font-weight: 600;
+}
+
+.btn.tk-add:not(:disabled):hover {
+  background: var(--ne-btn-primary-hover);
+  transform: translateY(-1px);
+}
+
+.btn.tk-add:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+  box-shadow: none;
+  transform: none;
+}
 
 /* Info poruka */
-.tk-note{margin-bottom:10px; opacity:.85}
+.tk-note {
+  margin-bottom: 12px;
+  padding: 10px 12px;
+  border-radius: 14px;
+  background: var(--ne-note-bg);
+  border: 1px solid var(--ne-note-border);
+  color: var(--ne-text);
+}
 
 /* Lista i kartice */
-.tk-list{display:flex;flex-direction:column;gap:12px;}
-.tk-card{border:1px solid rgba(255,255,255,0.12);border-radius:12px;padding:12px;background:rgba(255,255,255,0.04);}
-.tk-locked{opacity:.9}
-.tk-grid{display:grid;grid-template-columns:repeat(5, minmax(0,1fr)); gap:12px}
-@media (max-width: 1024px){
-  .tk-grid{grid-template-columns:repeat(2,minmax(0,1fr));}
+.tk-list {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
 }
-@media (max-width: 640px){
-  .tk-grid{grid-template-columns:1fr;}
+
+.tk-card {
+  border: 1px solid var(--ne-border);
+  border-radius: 18px;
+  padding: 16px;
+  background: var(--ne-surface-alt);
+  box-shadow: var(--ne-shadow-sm);
+  transition: border-color 0.15s ease, transform 0.12s ease, box-shadow 0.15s ease;
+}
+
+.tk-card:hover {
+  border-color: var(--ne-border-strong);
+  transform: translateY(-1px);
+  box-shadow: var(--ne-shadow-md);
+}
+
+.tk-card.tk-locked {
+  opacity: 0.9;
+}
+
+.tk-grid {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 12px;
+}
+
+@media (max-width: 1024px) {
+  .tk-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 640px) {
+  .tk-grid {
+    grid-template-columns: 1fr;
+  }
 }
 
 /* Boja */
-.tk-color-row{display:flex;align-items:center;gap:10px;}
-.tk-color-input{padding:0.25rem 0.5rem; height:40px}
-.tk-swatch{width:28px;height:28px;border-radius:6px;border:1px solid rgba(255,255,255,0.2)}
+.tk-color-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.tk-color-input {
+  padding: 0.25rem 0.5rem;
+  height: 40px;
+  background: var(--ne-input-bg);
+  border: 1px solid var(--ne-input-border);
+  border-radius: 10px;
+}
+
+.tk-color-input:focus {
+  outline: none;
+  border-color: var(--ne-input-border-focus);
+  box-shadow: var(--ne-input-shadow-focus);
+}
+
+.tk-swatch {
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  border: 1px solid var(--ne-border-strong);
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.35);
+}
 
 /* Akcije */
-.tk-actions{display:flex;gap:10px;justify-content:flex-end;margin-top:12px;}
+.tk-actions {
+  display: flex;
+  gap: 10px;
+  justify-content: flex-end;
+  margin-top: 16px;
+}
+
+.tk-actions .btn {
+  border-radius: 12px;
+  padding: 10px 18px;
+  border: 1px solid transparent;
+  background: var(--ne-btn-secondary);
+  color: var(--ne-text);
+  font-weight: 600;
+  transition: transform 0.15s ease, background 0.15s ease, border-color 0.15s ease;
+}
+
+.tk-actions .btn:not(:disabled):hover {
+  background: var(--ne-btn-secondary-hover);
+  border-color: var(--ne-border-strong);
+  transform: translateY(-1px);
+}
+
+.tk-actions .btn:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.tk-actions .btn:last-child {
+  background: var(--ne-btn-danger);
+  color: #fff;
+}
+
+.tk-actions .btn:last-child:not(:disabled):hover {
+  background: var(--ne-btn-danger-hover);
+}
 
 /* Disabled vizuelno kad je beskonačno ili nema ID-a */
 .tk-card input:disabled,
-.tk-card select:disabled{opacity:.6;cursor:not-allowed;background:rgba(255,255,255,0.06)}
+.tk-card select:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  background: rgba(255, 255, 255, 0.06);
+}


### PR DESCRIPTION
## Summary
- centralize reusable new-event colors and button helpers in the global index stylesheet
- restyle organizer subform stylesheets to share the same dark card, button, and table theme for a unified experience
- refresh the publish modal and basic info editor controls to match the updated palette

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_690d0e02fc20832aadd973add40087ff