### PR TITLE
Polish new event layout styling

### DIFF
--- a/src/frontend/EventOrganizerWeb/src/index.css
+++ b/src/frontend/EventOrganizerWeb/src/index.css
@@ -33,15 +33,145 @@
   --ne-input-shadow-focus: 0 0 0 3px rgba(139, 92, 246, 0.25);
 }
 html, body, #root { height: 100%; }
-body { @apply bg-bg text-white; }
 
-.form-card { @apply bg-bg-2 border border-white/10 rounded-xl2 p-6 shadow-soft; }
-.input { @apply w-full bg-bg-3 border border-white/10 rounded-lg px-3 py-2 outline-none focus:border-primary; }
-.label { @apply text-sm text-white/80; }
-.btn { @apply px-4 py-2 rounded-xl2 font-medium transition active:scale-[.98]; }
-.btn-primary { @apply bg-primary hover:bg-primary/90 text-white; }
-.btn-subtle { @apply bg-white/10 hover:bg-white/15; }
-.link { @apply text-accent hover:underline; }
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, 'Helvetica Neue', sans-serif;
+  color: var(--ne-text);
+  background:
+    radial-gradient(circle at 20% -10%, rgba(59, 130, 246, 0.18), transparent 60%),
+    radial-gradient(circle at 80% 0%, rgba(236, 72, 153, 0.12), transparent 55%),
+    #05060c;
+  min-height: 100vh;
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+}
+
+.form-card {
+  background: rgba(18, 18, 27, 0.92);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 22px;
+  padding: 28px;
+  box-shadow: 0 18px 44px rgba(6, 8, 20, 0.55);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+}
+
+.input {
+  width: 100%;
+  background: var(--ne-input-bg);
+  border: 1px solid var(--ne-input-border);
+  border-radius: 12px;
+  padding: 10px 14px;
+  color: var(--ne-text);
+  transition: border-color 0.15s ease, box-shadow 0.15s ease, background 0.15s ease, transform 0.12s ease;
+  appearance: none;
+}
+
+.input:focus {
+  outline: none;
+  border-color: var(--ne-input-border-focus);
+  box-shadow: var(--ne-input-shadow-focus);
+}
+
+.input::placeholder {
+  color: rgba(255, 255, 255, 0.4);
+}
+
+.input:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+  background: rgba(255, 255, 255, 0.06);
+}
+
+textarea.input {
+  resize: vertical;
+  min-height: 120px;
+}
+
+select.input {
+  background-image: linear-gradient(45deg, transparent 50%, rgba(255,255,255,0.35) 50%),
+    linear-gradient(135deg, rgba(255,255,255,0.35) 50%, transparent 50%);
+  background-position: calc(100% - 16px) calc(50% - 3px), calc(100% - 11px) calc(50% - 3px);
+  background-size: 7px 7px;
+  background-repeat: no-repeat;
+  padding-right: 36px;
+}
+
+.label {
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ne-text-muted);
+  font-weight: 600;
+}
+
+.btn {
+  border-radius: 14px;
+  border: 1px solid transparent;
+  font-weight: 600;
+  padding: 10px 18px;
+  color: var(--ne-text);
+  background: var(--ne-btn-secondary);
+  transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease, border-color 0.15s ease;
+  cursor: pointer;
+}
+
+.btn:not(:disabled):hover {
+  background: var(--ne-btn-secondary-hover);
+  border-color: var(--ne-border-strong);
+  transform: translateY(-1px);
+}
+
+.btn:not(:disabled):active {
+  transform: translateY(0);
+}
+
+.btn:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+.btn-primary {
+  background: var(--ne-btn-primary);
+  border-color: transparent;
+  color: #fff;
+  box-shadow: 0 12px 32px rgba(139, 92, 246, 0.4);
+}
+
+.btn-primary:not(:disabled):hover {
+  background: var(--ne-btn-primary-hover);
+  transform: translateY(-1px);
+}
+
+.btn-subtle {
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  color: var(--ne-text-muted);
+}
+
+.btn-subtle:not(:disabled):hover {
+  background: rgba(255, 255, 255, 0.12);
+  color: var(--ne-text);
+}
+
+.link {
+  color: #c4b5fd;
+  font-weight: 600;
+  text-decoration: none;
+  transition: color 0.15s ease, text-decoration-color 0.15s ease;
+}
+
+.link:hover {
+  color: #f472b6;
+  text-decoration: underline;
+}
 
 /* Shared helpers for new-event forms */
 .ne-panel {

--- a/src/frontend/EventOrganizerWeb/src/pages/Organizer/NewEvent/Activities.jsx
+++ b/src/frontend/EventOrganizerWeb/src/pages/Organizer/NewEvent/Activities.jsx
@@ -2,6 +2,7 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import toast from 'react-hot-toast';
 
+import Section from './Section';
 import '../../../styles/NewEvent/activities.css';
 
 import * as daysApi from '../../../services/daysApi';
@@ -364,12 +365,16 @@ export default function Activities({ eventId }){
   const disableForm = !hasEvent || saving;
 
   return (
-    <section className="act-wrap">
-      <div className="act-head">
-        <h2>Aktivnosti i raspored</h2>
-        {loading && <span className="act-badge">Učitavanje…</span>}
-      </div>
-
+    <Section
+      title="Aktivnosti i raspored"
+      subtitle="Planiraj program događaja kroz aktivnosti, njihove lokacije i termine."
+      badges={[
+        loading ? { label: 'Učitavanje...', tone: 'info' } : null,
+        saving ? { label: 'Čuvanje...', tone: 'info' } : null,
+        !hasEvent ? { label: 'Draft nije kreiran', tone: 'warning' } : null,
+        { label: `Aktivnosti: ${activities.length || 0}` },
+      ].filter(Boolean)}
+    >
       {!hasEvent && (
         <div className="act-note">Sačuvaj osnovne informacije o događaju da bi dodavao aktivnosti.</div>
       )}
@@ -538,6 +543,6 @@ export default function Activities({ eventId }){
           </table>
         </div>
       </div>
-    </section>
+    </Section>
   );
 }

--- a/src/frontend/EventOrganizerWeb/src/pages/Organizer/NewEvent/Areas.jsx
+++ b/src/frontend/EventOrganizerWeb/src/pages/Organizer/NewEvent/Areas.jsx
@@ -1,6 +1,8 @@
 // src/pages/Organizer/NewEvent/Areas.jsx
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import toast from 'react-hot-toast';
+
+import Section from './Section';
 import '../../../styles/NewEvent/areas.css';
 import * as areasApi from '../../../services/areasApi';
 import * as daysApi from '../../../services/daysApi'; // koristimo za dropdown dana
@@ -272,16 +274,26 @@ export default function Areas({ eventId }){
   }
 
 
-  return (
-    <div className="ar-wrap">
-      <div className="ar-head">
-        <div className="ar-title">Područja</div>
-        <div className="ar-spacer" />
-        {/* Koristim tvoj tekst: "Dodaj porcuje" */}
-        <button className="ar-btn" disabled={disabledAll || loading} onClick={addAreaCard}>Dodaj porcuje</button>
-      </div>
+  const headerBadges = [
+    loading ? { label: 'Učitavanje...', tone: 'info' } : null,
+    !eventId ? { label: 'Draft nije kreiran', tone: 'warning' } : null,
+    { label: `Područja: ${areas.length || 0}` },
+  ].filter(Boolean);
 
-      {!eventId && <div className="ar-note">Kreiraj draft događaja u "Basic info" da bi uređivao područja.</div>}
+  const addAreaButton = (
+    <button className="ar-btn" disabled={disabledAll || loading} onClick={addAreaCard}>
+      Dodaj područje
+    </button>
+  );
+
+  return (
+    <Section
+      title="Područja"
+      subtitle="Obeleži segmente događaja i poveži ih sa lokacijama i resursima."
+      badges={headerBadges}
+      actions={addAreaButton}
+    >
+      {!eventId && <div className="ar-note">Kreiraj draft događaja u "Osnovnim informacijama" da bi uređivao područja.</div>}
 
       {eventId && (
         <div className="ar-list">
@@ -300,7 +312,7 @@ export default function Areas({ eventId }){
           ))}
         </div>
       )}
-    </div>
+    </Section>
   );
 }
 

--- a/src/frontend/EventOrganizerWeb/src/pages/Organizer/NewEvent/BasicInfo.jsx
+++ b/src/frontend/EventOrganizerWeb/src/pages/Organizer/NewEvent/BasicInfo.jsx
@@ -1,9 +1,11 @@
 // src/pages/Organizer/NewEvent/BasicInfo.jsx
 import React, { useEffect, useMemo, useRef, useState } from 'react';
-import '../../../styles/NewEvent/basicinfo.css'; // FIX: one more ../
 import toast from 'react-hot-toast';
+
+import Section from './Section';
+import '../../../styles/NewEvent/basicinfo.css';
 import { getAuth } from '../../../utils/auth';
-import * as basicinfoApi from '../../../services/basicinfoapi';
+import * as basicInfoApi from '../../../services/basicInfoApi';
 import * as neweventApi from '../../../services/newEventApi';
 
 const KATEGORIJE = ['utakmica', 'protest', 'vašar', 'žurka', 'festival', 'ostalo'];
@@ -239,14 +241,14 @@ export default function BasicInfo({ eventId, onEventId, onBasicInfoChange }){
       try{
         setBusy(true);
         if(!eventId){
-          const created = await basicinfoApi.createDraft(payload);
+          const created = await basicInfoApi.createDraft(payload);
           const id = created?.id || created?.Id || created;
           if(id){
             onEventId?.(id);
             toast.success('Draft događaja je kreiran.');
           }
         }else{
-          await basicinfoApi.updateDraft(eventId, payload);
+          await basicInfoApi.updateDraft(eventId, payload);
         }
       }catch(err){
         const msg = err?.response?.data || 'Greška pri automatskom čuvanju.';
@@ -323,9 +325,20 @@ export default function BasicInfo({ eventId, onEventId, onBasicInfoChange }){
     }
   }
 
+  const headerBadges = [
+    busy ? { label: 'Sačuvaj u toku', tone: 'info' } : null,
+    eventId
+      ? { label: `Draft ID ${eventId}`, tone: 'success' }
+      : { label: 'Draft nije kreiran', tone: 'warning' }
+  ].filter(Boolean);
 
   return (
-    <div className="form-card space-y-5">
+    <Section
+      title="Osnovne informacije"
+      subtitle="Popuni ključne detalje o događaju. Kada ispuniš obavezna polja automatski kreiramo draft koji koriste ostale sekcije."
+      badges={headerBadges}
+    >
+      <div className="space-y-6">
       {/* Naziv / Lokacija */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         <label className="block">
@@ -452,6 +465,7 @@ export default function BasicInfo({ eventId, onEventId, onBasicInfoChange }){
           <img className="img-thumb" src={imgPreview} alt="preview" />
         )}
       </div>
-    </div>
+      </div>
+    </Section>
   );
 }

--- a/src/frontend/EventOrganizerWeb/src/pages/Organizer/NewEvent/Days.jsx
+++ b/src/frontend/EventOrganizerWeb/src/pages/Organizer/NewEvent/Days.jsx
@@ -1,6 +1,8 @@
 // src/pages/Organizer/NewEvent/Days.jsx
 import React, { useEffect, useState, useRef } from 'react';
 import toast from 'react-hot-toast';
+
+import Section from './Section';
 import '../../../styles/NewEvent/days.css';
 import * as neweventApi from '../../../services/newEventApi';
 import * as daysApi from '../../../services/daysApi';
@@ -334,58 +336,65 @@ export default function Days({ eventId }){
     }
   }
 
-  return (
-    <div className="dy-wrap">
-      <div className="dy-head">
-        <h3>Dani događaja</h3>
-      </div>
+  const lockedCount = days.filter((d) => d._locked).length;
+  const headerBadges = [
+    loading ? { label: 'Učitavanje...', tone: 'info' } : null,
+    !eventId ? { label: 'Draft nije kreiran', tone: 'warning' } : null,
+    range.count ? { label: `Planiranih dana: ${range.count}` } : null,
+    days.length ? { label: `Zaključano: ${lockedCount}/${days.length}` } : null,
+  ].filter(Boolean);
 
+  return (
+    <Section
+      title="Dani događaja"
+      subtitle="Prilagodi raspored i nazive pojedinačnih dana u skladu sa planom događaja."
+      badges={headerBadges}
+    >
       {!eventId && (
-        <div className="dy-note">Kreiraj draft događaja u "Basic info" da bi uređivao dane.</div>
+        <div className="dy-note">Kreiraj draft događaja u "Osnovnim informacijama" da bi uređivao dane.</div>
       )}
 
       {eventId && range.count === 0 && (
-        <div className="dy-note">Postavi datume u "Basic info" pa se vrati ovde da generišeš dane.</div>
+        <div className="dy-note">Postavi datume u "Osnovnim informacijama" kako bi se automatski generisali dani.</div>
       )}
 
       {eventId && range.count > 0 && (
-      <div className="dy-main">
-        <div className="dy-list">
-          {days.map((d, idx) => (
-            <div key={d.localId || idx} className={`dy-card ${d._locked ? 'is-locked' : ''}`}>
-              <div className="dy-card-head">
-                <div className="dy-title">Dan {d.RedniBroj}</div>
-                <div className="dy-badge">{d.DatumOdrzavanja}</div>
-                <div className="dy-spacer" />
-                <div className="dy-actions">
-                  <button className="dy-btn" disabled={!eventId || loading} onClick={()=>onToggle(idx)}>
-                    {d._locked ? 'Izmeni' : (d.Id ? 'Sačuvaj izmene' : 'Sačuvaj')}
-                  </button>
+        <div className="dy-main">
+          <div className="dy-list">
+            {days.map((d, idx) => (
+              <div key={d.localId || idx} className={`dy-card ${d._locked ? 'is-locked' : ''}`}>
+                <div className="dy-card-head">
+                  <div className="dy-title">Dan {d.RedniBroj}</div>
+                  <div className="dy-badge">{d.DatumOdrzavanja}</div>
+                  <div className="dy-spacer" />
+                  <div className="dy-actions">
+                    <button className="dy-btn" disabled={!eventId || loading} onClick={()=>onToggle(idx)}>
+                      {d._locked ? 'Izmeni' : (d.Id ? 'Sačuvaj izmene' : 'Sačuvaj')}
+                    </button>
+                  </div>
+                </div>
+
+                <div className="dy-sep" />
+
+                <div className="dy-grid">
+                  <label className="block">
+                    <div className="label mb-1">Naziv</div>
+                    <input className="input" value={d.Naziv} onChange={e=>onChange(idx,'Naziv', e.target.value)} disabled={loading || d._locked}/>
+                  </label>
+                  <label className="block">
+                    <div className="label mb-1">Opis</div>
+                    <input className="input" value={d.Opis} onChange={e=>onChange(idx,'Opis', e.target.value)} disabled={loading || d._locked}/>
+                  </label>
+                  <label className="block">
+                    <div className="label mb-1">Datum održavanja</div>
+                    <input className="input" type="date" value={d.DatumOdrzavanja} readOnly disabled/>
+                  </label>
                 </div>
               </div>
-
-              <div className="dy-sep" />
-
-              <div className="dy-grid">
-                <label className="block">
-                  <div className="label mb-1">Naziv</div>
-                  <input className="input" value={d.Naziv} onChange={e=>onChange(idx,'Naziv', e.target.value)} disabled={loading || d._locked}/>
-                </label>
-                <label className="block">
-                  <div className="label mb-1">Opis</div>
-                  <input className="input" value={d.Opis} onChange={e=>onChange(idx,'Opis', e.target.value)} disabled={loading || d._locked}/>
-                </label>
-                <label className="block">
-                  <div className="label mb-1">Datum održavanja</div>
-                  <input className="input" type="date" value={d.DatumOdrzavanja} readOnly disabled/>
-                </label>
-              </div>
-            </div>
-          ))}
+            ))}
+          </div>
         </div>
-      </div>
-    )}
-
-    </div>
+      )}
+    </Section>
   );
 }

--- a/src/frontend/EventOrganizerWeb/src/pages/Organizer/NewEvent/Locations.jsx
+++ b/src/frontend/EventOrganizerWeb/src/pages/Organizer/NewEvent/Locations.jsx
@@ -2,6 +2,7 @@
 import React, { useEffect, useMemo, useState, useCallback } from 'react';
 import toast from 'react-hot-toast';
 
+import Section from './Section';
 import '../../../styles/NewEvent/areas.css';
 import '../../../styles/NewEvent/locations.css';
 
@@ -484,14 +485,25 @@ export default function Locations({ eventId }){
     </th>
   );
 
-  return (
-    <div className="ar-wrap">
-      <div className="ar-head">
-        <div className="ar-title">Lokacije</div>
-        <div className="ar-spacer" />
-        <button className="ar-btn" disabled={!eventId || loading} onClick={newLocation}>+ Nova lokacija</button>
-      </div>
+  const headerBadges = [
+    loading ? { label: 'Učitavanje...', tone: 'info' } : null,
+    !eventId ? { label: 'Draft nije kreiran', tone: 'warning' } : null,
+    { label: `Lokacije: ${locations.length || 0}` },
+  ].filter(Boolean);
 
+  const addLocationButton = (
+    <button className="ar-btn" disabled={!eventId || loading} onClick={newLocation}>
+      Nova lokacija
+    </button>
+  );
+
+  return (
+    <Section
+      title="Lokacije"
+      subtitle="Poveži resurse sa konkretnim tačkama na mapi i dodeli ih odgovarajućim područjima."
+      badges={headerBadges}
+      actions={addLocationButton}
+    >
       <div className="ar-list" style={{ marginTop: 16 }}>
         {(locations || []).map((loc) => {
           const id = normalizeId(loc);
@@ -687,6 +699,6 @@ export default function Locations({ eventId }){
           )}
         </div>
       )}
-    </div>
+    </Section>
   );
 }

--- a/src/frontend/EventOrganizerWeb/src/pages/Organizer/NewEvent/NewEvent.jsx
+++ b/src/frontend/EventOrganizerWeb/src/pages/Organizer/NewEvent/NewEvent.jsx
@@ -10,6 +10,7 @@ import Areas from './Areas';
 import Locations from './Locations';
 import PriceList from './PriceList';
 import Activities from './Activities';
+import Section from './Section';
 
 import '../../../styles/NewEvent/NewEvent.css';
 
@@ -109,29 +110,48 @@ export default function NewEvent(){
   };
 
   return (
-    <div className="ne-container">
-      <h1 className="ne-title">Novi događaj</h1>
-      <p className="ne-subtitle">Popuni osnovne informacije. Kada sačuvaš obavezna polja, automatski pravimo draft događaja.</p>
+    <div className="ne-page">
+      <div className="ne-page__glow" aria-hidden />
+      <div className="ne-page__glow ne-page__glow--secondary" aria-hidden />
 
-      <BasicInfo
-        eventId={eventId}
-        onEventId={(id) => setEventId(id)}
-        onBasicInfoChange={({ capacity, infinite }) => {
-          setCapFromBasic(capacity);
-          setInfFromBasic(!!infinite);
-        }}
-      />
-      <Tickets eventId={eventId} initialCapacity={capFromBasic} initialInfinite={infFromBasic} />
-      <Days eventId={eventId} />
-      <Areas eventId={eventId} />
-      <Locations eventId={eventId} />
-      <PriceList eventId={eventId} />
-      <Activities eventId={eventId} />
+      <div className="ne-container">
+        <div className="ne-hero">
+          <span className="ne-hero__badge">Kreiraj događaj</span>
+          <h1 className="ne-title">Novi događaj</h1>
+          <p className="ne-subtitle">Popuni osnovne informacije i poveži sve podforme kako bi kreirao kompletan događaj spreman za objavu.</p>
+        </div>
 
-      <div className="publish-bar">
-        <button className="publish-btn" onClick={openPublishModal} disabled={!eventId}>
-          Publish događaj
-        </button>
+        <BasicInfo
+          eventId={eventId}
+          onEventId={(id) => setEventId(id)}
+          onBasicInfoChange={({ capacity, infinite }) => {
+            setCapFromBasic(capacity);
+            setInfFromBasic(!!infinite);
+          }}
+        />
+        <Tickets eventId={eventId} initialCapacity={capFromBasic} initialInfinite={infFromBasic} />
+        <Days eventId={eventId} />
+        <Areas eventId={eventId} />
+        <Locations eventId={eventId} />
+        <PriceList eventId={eventId} />
+        <Activities eventId={eventId} />
+
+        <Section
+          title="Objava događaja"
+          subtitle="Pregledaj kompletan draft i objavi događaj kada si spreman da ga podeliš sa posetiocima."
+          badges={[
+            eventId ? { label: `Draft ID ${eventId}`, tone: 'success' } : { label: 'Draft nije kreiran', tone: 'warning' },
+            publishState.published ? { label: 'Objavljeno', tone: 'success' } : { label: 'U pripremi', tone: 'info' },
+            publishState.loading ? { label: 'Priprema...', tone: 'info' } : null,
+          ].filter(Boolean)}
+          actions={(
+            <button className="publish-btn" onClick={openPublishModal} disabled={!eventId}>
+              Objavi događaj
+            </button>
+          )}
+        >
+          <p className="publish-hint">Objava je moguća tek nakon što popuniš sve obavezne sekcije i sačuvaš draft.</p>
+        </Section>
       </div>
 
       {publishState.open && (

--- a/src/frontend/EventOrganizerWeb/src/pages/Organizer/NewEvent/Section.jsx
+++ b/src/frontend/EventOrganizerWeb/src/pages/Organizer/NewEvent/Section.jsx
@@ -1,0 +1,100 @@
+import React from 'react';
+
+function normalizeBadges(badges){
+  if (!Array.isArray(badges)) return [];
+  return badges
+    .map((badge) => {
+      if (!badge) return null;
+      if (typeof badge === 'string') {
+        return { label: badge, tone: 'default' };
+      }
+      if (React.isValidElement(badge)) {
+        return { element: badge };
+      }
+      if (typeof badge === 'object') {
+        const { label, tone = 'default', element } = badge;
+        if (element && React.isValidElement(element)) {
+          return { element };
+        }
+        if (!label) return null;
+        return { label, tone };
+      }
+      return null;
+    })
+    .filter(Boolean);
+}
+
+function normalizeActions(actions){
+  if (!actions) return [];
+  return (Array.isArray(actions) ? actions : [actions]).filter(Boolean);
+}
+
+export default function Section({
+  title,
+  subtitle,
+  badges = [],
+  actions,
+  children,
+  className = '',
+  id,
+  headerAside,
+}) {
+  const normalizedBadges = normalizeBadges(badges);
+  const actionNodes = normalizeActions(actions);
+  const hasHeader = Boolean(
+    title ||
+    subtitle ||
+    normalizedBadges.length ||
+    actionNodes.length ||
+    headerAside
+  );
+
+  return (
+    <section className={["ne-section", className].filter(Boolean).join(' ')} id={id}>
+      {hasHeader && (
+        <header className="ne-section__header">
+          {(title || subtitle || normalizedBadges.length) && (
+            <div className="ne-section__heading">
+              {title && <h2 className="ne-section__title">{title}</h2>}
+              {subtitle && <p className="ne-section__subtitle">{subtitle}</p>}
+              {normalizedBadges.length > 0 && (
+                <div className="ne-section__badges">
+                  {normalizedBadges.map((badge, idx) => {
+                    if (badge.element) {
+                      return React.cloneElement(badge.element, { key: idx });
+                    }
+                    const toneClass = badge.tone && badge.tone !== 'default'
+                      ? ` ne-badge--${badge.tone}`
+                      : '';
+                    return (
+                      <span key={idx} className={`ne-badge${toneClass}`}>
+                        {badge.label}
+                      </span>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+          )}
+          {(actionNodes.length > 0 || headerAside) && (
+            <div className="ne-section__actions">
+              {headerAside && (
+                React.isValidElement(headerAside)
+                  ? React.cloneElement(headerAside)
+                  : <span>{headerAside}</span>
+              )}
+              {actionNodes.map((node, idx) => (
+                React.isValidElement(node)
+                  ? React.cloneElement(node, { key: idx })
+                  : <span key={idx}>{node}</span>
+              ))}
+            </div>
+          )}
+        </header>
+      )}
+      <div className="ne-section__body">
+        {children}
+      </div>
+    </section>
+  );
+}

--- a/src/frontend/EventOrganizerWeb/src/pages/Organizer/NewEvent/Tickets.jsx
+++ b/src/frontend/EventOrganizerWeb/src/pages/Organizer/NewEvent/Tickets.jsx
@@ -1,7 +1,9 @@
 // src/pages/Organizer/NewEvent/Tickets.jsx
 import React, { useEffect, useMemo, useRef, useState } from 'react';
-import '../../../styles/NewEvent/tickets.css';
 import toast from 'react-hot-toast';
+
+import Section from './Section';
+import '../../../styles/NewEvent/tickets.css';
 import * as ticketsApi from '../../../services/ticketsApi';
 import * as neweventApi from '../../../services/newEventApi';
 
@@ -326,22 +328,36 @@ export default function Tickets({ eventId, initialCapacity, initialInfinite }){
   const disabledGlobal = !eventId || loading;
   const disableAdd = disabledGlobal || saving || infinite;
 
-  return (
-    <div className="form-card tk-wrap">
-      <div className="tk-head">
-        <div className="label">Karte</div>
-        <div className="grow" />
-        <button className="btn tk-add" onClick={addTicket} disabled={disableAdd}>
-          Dodaj kartu
-        </button>
-      </div>
+  const headerBadges = [
+    loading ? { label: 'Učitavanje...', tone: 'info' } : null,
+    saving ? { label: 'Čuvanje...', tone: 'info' } : null,
+    infinite
+      ? { label: 'Beskonačan kapacitet', tone: 'warning' }
+      : (Number.isFinite(Number(capacity))
+        ? { label: `Raspoređeno ${manualTotal}/${capacity}` }
+        : null),
+    { label: `Tipova ulaznica: ${tickets.length || 0}` },
+  ].filter(Boolean);
 
+  const addButton = (
+    <button className="btn btn-primary tk-add" onClick={addTicket} disabled={disableAdd}>
+      Dodaj kartu
+    </button>
+  );
+
+  return (
+    <Section
+      title="Karte"
+      subtitle="Definiši tipove ulaznica, cene i količine koje posetioci mogu da rezervišu."
+      badges={headerBadges}
+      actions={addButton}
+    >
       {!eventId && (
-        <div className="tk-note">Kreiraj draft događaja u "Basic info" da bi dodavao karte.</div>
+        <div className="tk-note">Kreiraj draft događaja u "Osnovnim informacijama" pre dodavanja karata.</div>
       )}
 
       {infinite && (
-        <div className="tk-note">Kapacitet je beskonačan – automatski je dodata besplatna karta. Možeš promeniti samo boju.</div>
+        <div className="tk-note">Kapacitet je beskonačan – automatski je dodata besplatna karta. Možeš da promeniš samo boju.</div>
       )}
 
       {!infinite && Number.isFinite(Number(capacity)) && (
@@ -406,6 +422,6 @@ export default function Tickets({ eventId, initialCapacity, initialInfinite }){
           );
         })}
       </div>
-    </div>
+    </Section>
   );
 }

--- a/src/frontend/EventOrganizerWeb/src/styles/NewEvent/NewEvent.css
+++ b/src/frontend/EventOrganizerWeb/src/styles/NewEvent/NewEvent.css
@@ -1,12 +1,218 @@
-.publish-bar {
-  margin-top: 32px;
+.ne-page {
+  position: relative;
+  min-height: 100vh;
   display: flex;
-  justify-content: flex-end;
+  justify-content: center;
+  padding: 96px 0 160px;
+  background:
+    radial-gradient(circle at 15% 5%, rgba(59, 130, 246, 0.22), transparent 60%),
+    radial-gradient(circle at 85% 0%, rgba(236, 72, 153, 0.18), transparent 58%),
+    linear-gradient(180deg, rgba(7, 7, 15, 0.96), rgba(3, 3, 9, 0.98));
+  overflow: hidden;
+}
+
+.ne-page__glow {
+  position: absolute;
+  width: 520px;
+  height: 520px;
+  border-radius: 999px;
+  background: radial-gradient(circle, rgba(139, 92, 246, 0.45), transparent 70%);
+  filter: blur(0px);
+  opacity: 0.75;
+  top: -140px;
+  right: -120px;
+  pointer-events: none;
+}
+
+.ne-page__glow--secondary {
+  width: 420px;
+  height: 420px;
+  background: radial-gradient(circle, rgba(37, 99, 235, 0.4), transparent 70%);
+  bottom: 60px;
+  left: -140px;
+  top: auto;
+  opacity: 0.6;
+}
+
+.ne-container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 48px clamp(16px, 5vw, 56px) 120px;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+  position: relative;
+  z-index: 2;
+  width: min(1200px, calc(100% - 48px));
+}
+
+.ne-hero {
+  position: relative;
+  padding: 36px clamp(24px, 4vw, 48px);
+  border-radius: 28px;
+  background: linear-gradient(135deg, rgba(139, 92, 246, 0.38), rgba(37, 99, 235, 0.22));
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow: 0 28px 64px rgba(10, 10, 25, 0.55);
+  overflow: hidden;
+  backdrop-filter: blur(26px);
+  -webkit-backdrop-filter: blur(26px);
+}
+
+.ne-hero::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top right, rgba(255, 255, 255, 0.12), transparent 55%),
+              radial-gradient(circle at bottom left, rgba(139, 92, 246, 0.18), transparent 60%);
+  pointer-events: none;
+  mix-blend-mode: screen;
+}
+
+.ne-hero__badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 14px;
+  border-radius: 999px;
+  background: rgba(17, 24, 39, 0.45);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ne-text-muted);
+  position: relative;
+  z-index: 1;
+}
+
+.ne-title {
+  position: relative;
+  z-index: 1;
+  font-size: clamp(2.2rem, 4vw, 3rem);
+  font-weight: 700;
+  margin-top: 14px;
+  margin-bottom: 8px;
+  background: linear-gradient(120deg, #ffffff, rgba(214, 205, 255, 0.85));
+  -webkit-background-clip: text;
+  color: transparent;
+}
+
+.ne-subtitle {
+  position: relative;
+  z-index: 1;
+  color: var(--ne-text-muted);
+  font-size: 1.05rem;
+  max-width: 720px;
+  line-height: 1.6;
+}
+
+.ne-section {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 22px;
+  padding: 28px clamp(20px, 3vw, 34px);
+  border-radius: 26px;
+  background: rgba(18, 18, 27, 0.92);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 18px 40px rgba(6, 8, 20, 0.55);
+  overflow: hidden;
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+}
+
+.ne-section::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background:
+    linear-gradient(140deg, rgba(139, 92, 246, 0.18), transparent 65%),
+    linear-gradient(20deg, rgba(59, 130, 246, 0.12), transparent 70%);
+  pointer-events: none;
+}
+
+.ne-section__header {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 18px;
+}
+
+.ne-section__heading {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  max-width: min(100%, 640px);
+}
+
+.ne-section__title {
+  font-size: 1.45rem;
+  font-weight: 700;
+  color: var(--ne-text-strong);
+}
+
+.ne-section__subtitle {
+  color: var(--ne-text-muted);
+  line-height: 1.6;
+}
+
+.ne-section__badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.ne-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 14px;
+  border-radius: 999px;
+  font-size: 0.82rem;
+  font-weight: 600;
+  background: var(--ne-pill-bg);
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  color: var(--ne-pill-text);
+}
+
+.ne-badge--info {
+  background: rgba(59, 130, 246, 0.18);
+  color: #bfdbfe;
+  border-color: rgba(59, 130, 246, 0.35);
+}
+
+.ne-badge--warning {
+  background: rgba(245, 158, 11, 0.2);
+  color: #fde68a;
+  border-color: rgba(245, 158, 11, 0.35);
+}
+
+.ne-badge--success {
+  background: rgba(34, 197, 94, 0.2);
+  color: #bbf7d0;
+  border-color: rgba(34, 197, 94, 0.35);
+}
+
+.ne-section__actions {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.ne-section__body {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
 }
 
 .publish-btn,
 .publish-btn-secondary {
-  padding: 10px 18px;
+  padding: 10px 20px;
   border-radius: 12px;
   border: 1px solid transparent;
   font-weight: 600;
@@ -17,7 +223,7 @@
 .publish-btn {
   background: var(--ne-btn-primary);
   color: #fff;
-  box-shadow: 0 10px 28px rgba(139, 92, 246, 0.35);
+  box-shadow: 0 12px 32px rgba(139, 92, 246, 0.4);
 }
 
 .publish-btn:hover:not([disabled]) {
@@ -36,11 +242,15 @@
   background: var(--ne-btn-secondary);
   border-color: var(--ne-border-strong);
   color: var(--ne-text);
-  margin-left: 12px;
 }
 
 .publish-btn-secondary:hover:not([disabled]) {
   background: var(--ne-btn-secondary-hover);
+}
+
+.publish-hint {
+  color: var(--ne-text-muted);
+  font-size: 0.95rem;
 }
 
 .publish-modal__backdrop {
@@ -54,15 +264,17 @@
 }
 
 .publish-modal {
-  background: var(--ne-surface);
+  background: rgba(18, 18, 27, 0.92);
   width: min(720px, 90%);
   border-radius: 20px;
-  box-shadow: var(--ne-shadow-md);
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.55);
   display: flex;
   flex-direction: column;
   max-height: 80vh;
-  border: 1px solid var(--ne-border);
+  border: 1px solid rgba(255, 255, 255, 0.12);
   color: var(--ne-text);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
 }
 
 .publish-modal__head {
@@ -101,8 +313,13 @@
   border: 1px solid rgba(239, 68, 68, 0.35);
 }
 
+
 .publish-modal__content section {
   margin-bottom: 18px;
+  padding: 14px 16px;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid rgba(255, 255, 255, 0.06);
 }
 
 .publish-modal__content h4 {
@@ -115,28 +332,45 @@
 .publish-modal__content ul {
   padding-left: 18px;
   color: var(--ne-text-muted);
+  margin: 0;
 }
 
 .publish-modal__raw pre {
-  background: rgba(12, 12, 24, 0.95);
+  background: rgba(12, 12, 24, 0.92);
   color: var(--ne-text);
   padding: 16px;
   border-radius: 12px;
   max-height: 220px;
   overflow: auto;
   font-size: 0.85rem;
-  border: 1px solid rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
 }
 
-@media (max-width: 640px) {
+@media (max-width: 768px) {
+  .ne-page {
+    padding: 72px 0 120px;
+  }
+
+  .ne-container {
+    padding: 32px 16px 96px;
+    width: calc(100% - 32px);
+  }
+
+  .ne-hero {
+    padding: 28px 24px;
+  }
+
+  .ne-section {
+    padding: 24px 20px;
+  }
+
   .publish-modal {
     width: 94%;
   }
+
   .publish-modal__actions {
     flex-direction: column;
     align-items: stretch;
-  }
-  .publish-btn-secondary {
-    margin-left: 0;
   }
 }

--- a/src/frontend/EventOrganizerWeb/src/styles/NewEvent/activities.css
+++ b/src/frontend/EventOrganizerWeb/src/styles/NewEvent/activities.css
@@ -1,38 +1,3 @@
-.act-wrap {
-  margin-top: 32px;
-  padding: 24px;
-  border-radius: 20px;
-  background: var(--ne-surface);
-  border: 1px solid var(--ne-border);
-  box-shadow: var(--ne-shadow-sm);
-  color: var(--ne-text);
-}
-
-.act-head {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  margin-bottom: 18px;
-  gap: 12px;
-}
-
-.act-head h2 {
-  font-size: 1.4rem;
-  font-weight: 700;
-  color: var(--ne-text-strong);
-}
-
-.act-badge {
-  padding: 6px 12px;
-  border-radius: 999px;
-  background: var(--ne-pill-bg);
-  color: var(--ne-pill-text);
-  font-weight: 600;
-  font-size: 0.85rem;
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  box-shadow: 0 6px 16px rgba(139, 92, 246, 0.18);
-}
-
 .act-note {
   background: var(--ne-note-bg);
   border: 1px solid var(--ne-note-border);

--- a/src/frontend/EventOrganizerWeb/src/styles/NewEvent/areas.css
+++ b/src/frontend/EventOrganizerWeb/src/styles/NewEvent/areas.css
@@ -1,24 +1,3 @@
-/* src/styles/NewEvent/areas.css */
-.ar-wrap {
-  margin-top: 32px;
-}
-
-.ar-head {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-}
-
-.ar-title {
-  font-weight: 700;
-  font-size: 1.2rem;
-  color: var(--ne-text-strong);
-}
-
-.ar-spacer {
-  flex: 1;
-}
-
 .ar-btn {
   padding: 10px 16px;
   border: 1px solid var(--ne-border-strong);

--- a/src/frontend/EventOrganizerWeb/src/styles/NewEvent/days.css
+++ b/src/frontend/EventOrganizerWeb/src/styles/NewEvent/days.css
@@ -1,17 +1,5 @@
 /* src/styles/NewEvent/days.css */
 
-/* Wrapper i header (u skladu sa tickets.css/basicinfo.css) */
-.dy-wrap {
-  margin-top: 32px;
-}
-
-.dy-head {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  margin-bottom: 16px;
-}
-
 .dy-title {
   font-size: 1.3rem;
   font-weight: 600;
@@ -52,11 +40,9 @@
 
 /* Lista i kartice */
 .dy-main {
-  border: 1px solid var(--ne-border);
-  border-radius: 20px;
-  padding: 18px;
-  background: var(--ne-surface);
-  box-shadow: var(--ne-shadow-sm);
+  border-radius: 18px;
+  padding: 4px;
+  background: linear-gradient(135deg, rgba(139, 92, 246, 0.08), transparent);
 }
 
 .dy-list {

--- a/src/frontend/EventOrganizerWeb/src/styles/NewEvent/pricelist.css
+++ b/src/frontend/EventOrganizerWeb/src/styles/NewEvent/pricelist.css
@@ -1,55 +1,27 @@
 /* src/styles/NewEvent/pricelist.css */
 
-.pl-section {
-  margin-top: 32px;
-  border: 1px solid var(--ne-border);
-  border-radius: 20px;
-  padding: 24px;
-  background: var(--ne-surface);
-  box-shadow: var(--ne-shadow-sm);
-  color: var(--ne-text);
-}
 
-.pl-header {
-  display: flex;
-  align-items: center;
-  gap: 16px;
-  margin-bottom: 20px;
-}
-
-.pl-header h2 {
-  font-size: 1.4rem;
-  font-weight: 700;
-  color: var(--ne-text-strong);
-}
-
-.pl-header .pl-subtitle {
-  margin-left: auto;
-  font-size: 0.95rem;
-  color: var(--ne-text-muted);
-}
-
-.pl-header .pl-btn-inline {
-  margin-left: auto;
-}
-
-.pl-topbar {
+.pl-header-controls {
   display: flex;
   align-items: center;
   gap: 12px;
-  margin-bottom: 18px;
 }
 
-.pl-badge {
-  display: inline-flex;
-  align-items: center;
-  padding: 4px 10px;
-  border-radius: 999px;
-  background: var(--ne-pill-bg);
-  color: var(--ne-pill-text);
-  font-weight: 600;
+.pl-header-controls select {
+  min-width: 240px;
+}
+
+.pl-status {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  color: var(--ne-text-muted);
+  font-size: 0.95rem;
+}
+
+.pl-status__hint {
   font-size: 0.85rem;
-  border: 1px solid rgba(255, 255, 255, 0.12);
+  color: var(--ne-text-faint);
 }
 
 .pl-meta {

--- a/src/frontend/EventOrganizerWeb/src/styles/NewEvent/tickets.css
+++ b/src/frontend/EventOrganizerWeb/src/styles/NewEvent/tickets.css
@@ -1,24 +1,6 @@
 /* src/styles/NewEvent/tickets.css */
 
-/* Wrapper i header */
-.tk-wrap {
-  margin-top: 32px;
-}
-
-.tk-head {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  margin-bottom: 16px;
-}
-
-.tk-head h2 {
-  font-size: 1.3rem;
-  font-weight: 600;
-  color: var(--ne-text-strong);
-}
-
-.btn.tk-add {
+.tk-add {
   background: var(--ne-btn-primary);
   border: 1px solid transparent;
   border-radius: 12px;
@@ -27,12 +9,12 @@
   font-weight: 600;
 }
 
-.btn.tk-add:not(:disabled):hover {
+.tk-add:not(:disabled):hover {
   background: var(--ne-btn-primary-hover);
   transform: translateY(-1px);
 }
 
-.btn.tk-add:disabled {
+.tk-add:disabled {
   opacity: 0.55;
   cursor: not-allowed;
   box-shadow: none;


### PR DESCRIPTION
## Summary
- wrap the new-event flow in a dedicated page shell with ambient gradient glows and refreshed section surfaces
- align shared form controls/buttons with the new dark theme so every subform inherits consistent styling cues
- refine publish modal visuals with glassmorphism accents and structured content blocks

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_690d143e5ad4832a972e529691414b4e