### PR TITLE
Refine layouts for new event subforms

### DIFF
--- a/src/frontend/EventOrganizerWeb/src/pages/Organizer/NewEvent/Locations.jsx
+++ b/src/frontend/EventOrganizerWeb/src/pages/Organizer/NewEvent/Locations.jsx
@@ -615,6 +615,46 @@ export default function Locations({ eventId }){
           )}
 
           <div className="loc-res-wrap">
+            <div className="loc-res-form">
+              <h3 className="loc-res-title">Dodaj resurs</h3>
+              <label className="loc-res-field">
+                <span>Dobavljač</span>
+                <select className="select" value={selSupplier} onChange={e=>setSelSupplier(e.target.value)} disabled={lock}>
+                  <option value="">-- izaberi --</option>
+                  {suppliers.map(s => {
+                    const id = String(normalizeId(s));
+                    const name = s?.Naziv || s?.naziv || 'Dobavljač';
+                    return <option key={id} value={id}>{name}</option>;
+                  })}
+                </select>
+              </label>
+
+              <label className="loc-res-field">
+                <span>Resurs</span>
+                <select className="select" value={selResource} onChange={e=>setSelResource(e.target.value)} disabled={lock || !selSupplier}>
+                  <option value="">-- izaberi --</option>
+                  {(selSupplier ? filteredResources : resources).map(r => {
+                    const id = String(normalizeId(r));
+                    const name = r?.Naziv || r?.naziv || 'Resurs';
+                    const tip = r?.Tip || r?.tip || '';
+                    return <option key={id} value={id}>{name} · {tip}</option>;
+                  })}
+                </select>
+              </label>
+              {selSupplier && filteredResources.length === 0 && (
+                <div className="ar-note">Ovaj dobavljač nema dostupne resurse.</div>
+              )}
+
+              <label className="loc-res-field">
+                <span>Količina</span>
+                <input className="input" type="number" value={qty} onChange={e=>setQty(e.target.value)} disabled={lock || !selResource} />
+              </label>
+
+              <div className="loc-res-actions">
+                <button className="ar-btn" onClick={addResource} disabled={lock}>Dodaj resurs</button>
+              </div>
+            </div>
+
             <div className="loc-res-table">
               <div className="label">Rezervisani resursi</div>
               <table className="loc-table">
@@ -648,39 +688,6 @@ export default function Locations({ eventId }){
                   )}
                 </tbody>
               </table>
-            </div>
-
-            <div className="loc-res-form">
-              <div className="label">Dobavljač</div>
-              <select className="select" value={selSupplier} onChange={e=>setSelSupplier(e.target.value)} disabled={lock}>
-                <option value="">-- izaberi --</option>
-                {suppliers.map(s => {
-                  const id = String(normalizeId(s));
-                  const name = s?.Naziv || s?.naziv || 'Dobavljač';
-                  return <option key={id} value={id}>{name}</option>;
-                })}
-              </select>
-
-              <div className="label" style={{ marginTop: 8 }}>Resurs</div>
-              <select className="select" value={selResource} onChange={e=>setSelResource(e.target.value)} disabled={lock || !selSupplier}>
-                <option value="">-- izaberi --</option>
-                {(selSupplier ? filteredResources : resources).map(r => {
-                  const id = String(normalizeId(r));
-                  const name = r?.Naziv || r?.naziv || 'Resurs';
-                  const tip = r?.Tip || r?.tip || '';
-                  return <option key={id} value={id}>{name} · {tip}</option>;
-                })}
-              </select>
-              {selSupplier && filteredResources.length === 0 && (
-                <div className="ar-note">Ovaj dobavljač nema dostupne resurse.</div>
-              )}
-
-              <div className="label" style={{ marginTop: 8 }}>Količina</div>
-              <input className="input" type="number" value={qty} onChange={e=>setQty(e.target.value)} disabled={lock || !selResource} />
-
-              <div style={{ marginTop: 10 }}>
-                <button className="ar-btn" onClick={addResource} disabled={lock}>Dodaj resurs</button>
-              </div>
             </div>
           </div>
 

--- a/src/frontend/EventOrganizerWeb/src/pages/Organizer/NewEvent/PriceList.jsx
+++ b/src/frontend/EventOrganizerWeb/src/pages/Organizer/NewEvent/PriceList.jsx
@@ -665,47 +665,6 @@ export default function PriceList({ eventId }){
       </div>
 
       <div className="pl-content">
-        <div className="pl-table-wrap">
-          <table className="pl-table">
-            <thead>
-              <tr>
-                <th>Naziv</th>
-                <th>Opis</th>
-                <th>Cena</th>
-                <th>Količina</th>
-                {isEditable && <th>Akcije</th>}
-              </tr>
-            </thead>
-            <tbody>
-              {items.length === 0 && (
-                <tr>
-                  <td className="pl-empty" colSpan={isEditable ? 5 : 4}>Nema stavki u cenovniku.</td>
-                </tr>
-              )}
-              {items.map((item) => (
-                <tr key={item.localId}>
-                  <td>
-                    {item.Naziv}
-                    {item.status === 'new' && <span className="pl-pill">novo</span>}
-                    {item.status === 'updated' && <span className="pl-pill">izmena</span>}
-                  </td>
-                  <td>{item.Opis || <span className="pl-hint">Nema opisa</span>}</td>
-                  <td>{Number(item.Cena || 0).toLocaleString('sr-RS', { minimumFractionDigits: 2, maximumFractionDigits: 2 })} RSD</td>
-                  <td>{Number(item.Kolicina || 0).toLocaleString('sr-RS')}</td>
-                  {isEditable && (
-                    <td>
-                      <div className="pl-row-actions">
-                        <button className="pl-btn pl-secondary" onClick={() => handleEditItem(item.localId)} type="button">Uredi</button>
-                        <button className="pl-btn pl-danger" onClick={() => handleRemoveItem(item.localId)} type="button">Ukloni</button>
-                      </div>
-                    </td>
-                  )}
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-
         <div className="pl-form-wrap">
           <form className="pl-item-form" onSubmit={addOrUpdateItem}>
             <h3>{editingItemLocalId ? 'Izmeni stavku' : 'Nova stavka'}</h3>
@@ -773,6 +732,47 @@ export default function PriceList({ eventId }){
               )}
             </div>
           </form>
+        </div>
+
+        <div className="pl-table-wrap">
+          <table className="pl-table">
+            <thead>
+              <tr>
+                <th>Naziv</th>
+                <th>Opis</th>
+                <th>Cena</th>
+                <th>Količina</th>
+                {isEditable && <th>Akcije</th>}
+              </tr>
+            </thead>
+            <tbody>
+              {items.length === 0 && (
+                <tr>
+                  <td className="pl-empty" colSpan={isEditable ? 5 : 4}>Nema stavki u cenovniku.</td>
+                </tr>
+              )}
+              {items.map((item) => (
+                <tr key={item.localId}>
+                  <td>
+                    {item.Naziv}
+                    {item.status === 'new' && <span className="pl-pill">novo</span>}
+                    {item.status === 'updated' && <span className="pl-pill">izmena</span>}
+                  </td>
+                  <td>{item.Opis || <span className="pl-hint">Nema opisa</span>}</td>
+                  <td>{Number(item.Cena || 0).toLocaleString('sr-RS', { minimumFractionDigits: 2, maximumFractionDigits: 2 })} RSD</td>
+                  <td>{Number(item.Kolicina || 0).toLocaleString('sr-RS')}</td>
+                  {isEditable && (
+                    <td>
+                      <div className="pl-row-actions">
+                        <button className="pl-btn pl-secondary" onClick={() => handleEditItem(item.localId)} type="button">Uredi</button>
+                        <button className="pl-btn pl-danger" onClick={() => handleRemoveItem(item.localId)} type="button">Ukloni</button>
+                      </div>
+                    </td>
+                  )}
+                </tr>
+              ))}
+            </tbody>
+          </table>
         </div>
       </div>
 

--- a/src/frontend/EventOrganizerWeb/src/styles/NewEvent/activities.css
+++ b/src/frontend/EventOrganizerWeb/src/styles/NewEvent/activities.css
@@ -9,8 +9,9 @@
 
 .act-grid {
   display: grid;
-  grid-template-columns: minmax(280px, 1fr) minmax(360px, 1fr);
+  grid-template-columns: minmax(280px, 320px) 1fr;
   gap: 24px;
+  align-items: start;
 }
 
 @media (max-width: 900px) {
@@ -72,15 +73,9 @@
 }
 
 .act-two-col {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  display: flex;
+  flex-direction: column;
   gap: 12px;
-}
-
-@media (max-width: 520px) {
-  .act-two-col {
-    grid-template-columns: 1fr;
-  }
 }
 
 .act-actions {

--- a/src/frontend/EventOrganizerWeb/src/styles/NewEvent/locations.css
+++ b/src/frontend/EventOrganizerWeb/src/styles/NewEvent/locations.css
@@ -15,9 +15,10 @@
 
 .loc-res-wrap {
   display: grid;
-  grid-template-columns: 7fr 3fr;
+  grid-template-columns: minmax(260px, 320px) 1fr;
   gap: 16px;
   margin-top: 18px;
+  align-items: start;
 }
 
 @media (max-width: 1100px) {
@@ -33,6 +34,35 @@
   background: var(--ne-surface-alt);
   padding: 16px;
   box-shadow: var(--ne-shadow-sm);
+}
+
+.loc-res-form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.loc-res-title {
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: var(--ne-text-strong);
+  margin: 0;
+}
+
+.loc-res-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.loc-res-field span {
+  font-weight: 600;
+  color: var(--ne-text-muted);
+}
+
+.loc-res-actions {
+  display: flex;
+  justify-content: flex-start;
 }
 
 .loc-table {

--- a/src/frontend/EventOrganizerWeb/src/styles/NewEvent/pricelist.css
+++ b/src/frontend/EventOrganizerWeb/src/styles/NewEvent/pricelist.css
@@ -122,19 +122,21 @@
 }
 
 .pl-content {
-  display: flex;
+  display: grid;
+  grid-template-columns: minmax(260px, 340px) 1fr;
   gap: 24px;
-  flex-wrap: wrap;
+  align-items: start;
 }
 
-.pl-table-wrap {
-  flex: 3;
-  min-width: 320px;
+@media (max-width: 960px) {
+  .pl-content {
+    grid-template-columns: 1fr;
+  }
 }
 
+.pl-table-wrap,
 .pl-form-wrap {
-  flex: 2;
-  min-width: 260px;
+  min-width: 0;
 }
 
 .pl-table {
@@ -176,11 +178,22 @@
 .pl-item-form {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 16px;
   padding: 18px;
   border: 1px dashed rgba(139, 92, 246, 0.35);
   border-radius: 14px;
   background: var(--ne-surface-alt);
+}
+
+.pl-item-form .pl-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.pl-item-form label {
+  font-weight: 600;
+  color: var(--ne-text-muted);
 }
 
 .pl-item-form h3 {
@@ -241,8 +254,8 @@
 }
 
 .pl-item-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  display: flex;
+  flex-direction: column;
   gap: 12px;
 }
 


### PR DESCRIPTION
## Summary
- swap the resource and price list subform layouts so inputs appear on the left and tables on the right
- stack every subform field with its label above the control for resources, price list items, and activities
- refresh supporting styles to align grid spacing and typography with the updated layouts

## Testing
- npm test -- --watchAll=false --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_e_690d1c5ef6a4832a8c20da6a2baba1ee