### PR TITLE
Filter event data and align location colors

### DIFF
--- a/src/backend/EventOrganizerAPI/Controllers/AktivnostController.cs
+++ b/src/backend/EventOrganizerAPI/Controllers/AktivnostController.cs
@@ -30,6 +30,13 @@ namespace EventOrganizerAPI.Controllers
             return Ok(rezultat);
         }
 
+        [HttpGet("dogadjaj/{dogadjajId}")]
+        public async Task<IActionResult> VratiZaDogadjaj(string dogadjajId)
+        {
+            var rezultat = await _servis.VratiZaDogadjaj(dogadjajId);
+            return Ok(rezultat);
+        }
+
         [HttpGet("vrati-po-id/{id}")]
         public async Task<IActionResult> VratiPoId(string id)
         {

--- a/src/backend/EventOrganizerAPI/Controllers/CenovnikController.cs
+++ b/src/backend/EventOrganizerAPI/Controllers/CenovnikController.cs
@@ -1,5 +1,5 @@
 using EventOrganizerAPI.DTOs.Cenovnik;
-using EventOrganizerAPI.Services;
+using EventOrganizerAPI.Services.Interfaces;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using System.Threading.Tasks;
@@ -10,9 +10,9 @@ namespace EventOrganizerAPI.Controllers
     [Route("api/cenovnici")]
     public class CenovnikController : ControllerBase
     {
-        private readonly CenovnikServis _cenovnikServis;
+        private readonly ICenovnikServis _cenovnikServis;
 
-        public CenovnikController(CenovnikServis cenovnikServis)
+        public CenovnikController(ICenovnikServis cenovnikServis)
         {
             _cenovnikServis = cenovnikServis;
         }
@@ -28,6 +28,13 @@ namespace EventOrganizerAPI.Controllers
         public async Task<IActionResult> VratiSve()
         {
             var lista = await _cenovnikServis.VratiSveCenovnikeAsync();
+            return Ok(lista);
+        }
+
+        [HttpGet("dogadjaj/{dogadjajId}")]
+        public async Task<IActionResult> VratiZaDogadjaj(string dogadjajId)
+        {
+            var lista = await _cenovnikServis.VratiSveZaDogadjajAsync(dogadjajId);
             return Ok(lista);
         }
 

--- a/src/backend/EventOrganizerAPI/DTOs/Cenovnik/AzurirajCenovnikDto.cs
+++ b/src/backend/EventOrganizerAPI/DTOs/Cenovnik/AzurirajCenovnikDto.cs
@@ -7,6 +7,7 @@ namespace EventOrganizerAPI.DTOs.Cenovnik
         public string? Id { get; set; }
         public string? Naziv { get; set; }
         public string? LokacijaId { get; set; }
+        public string? DogadjajId { get; set; }
         public List<string>? StavkeIds { get; set; }
     }
 }

--- a/src/backend/EventOrganizerAPI/DTOs/Cenovnik/KreirajCenovnikDto.cs
+++ b/src/backend/EventOrganizerAPI/DTOs/Cenovnik/KreirajCenovnikDto.cs
@@ -11,6 +11,9 @@ namespace EventOrganizerAPI.DTOs.Cenovnik
         [Required]
         public string LokacijaId { get; set; }
 
+        [Required]
+        public string DogadjajId { get; set; }
+
         public List<string> StavkeIds { get; set; } = new();
     }
 }

--- a/src/backend/EventOrganizerAPI/DTOs/Cenovnik/PrikaziCenovnikDto.cs
+++ b/src/backend/EventOrganizerAPI/DTOs/Cenovnik/PrikaziCenovnikDto.cs
@@ -7,6 +7,7 @@ namespace EventOrganizerAPI.DTOs.Cenovnik
         public string Id { get; set; }
         public string Naziv { get; set; }
         public string LokacijaId { get; set; }
+        public string DogadjajId { get; set; }
         public List<string> StavkeIds { get; set; }
     }
 }

--- a/src/backend/EventOrganizerAPI/Models/Cenovnik.cs
+++ b/src/backend/EventOrganizerAPI/Models/Cenovnik.cs
@@ -1,5 +1,6 @@
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Attributes;
+using System.Collections.Generic;
 
 namespace EventOrganizerAPI.Models
 {
@@ -11,7 +12,13 @@ namespace EventOrganizerAPI.Models
 
         public string Naziv {  get; set; }
 
+        [BsonRepresentation(BsonType.ObjectId)]
+        public string DogadjajId { get; set; }
+
+        [BsonRepresentation(BsonType.ObjectId)]
         public string LokacijaId { get; set; }
+
+        [BsonRepresentation(BsonType.ObjectId)]
         public List<string> Stavke { get; set; }
 
     }

--- a/src/backend/EventOrganizerAPI/Program.cs
+++ b/src/backend/EventOrganizerAPI/Program.cs
@@ -135,7 +135,7 @@ namespace EventOrganizerAPI
             builder.Services.AddScoped<INapomenaServis, NapomenaServis>();
             builder.Services.AddScoped<INotifikacijeServis, NotifikacijaServis>();
             builder.Services.AddScoped<IKartaServis, KartaServis>();
-            builder.Services.AddScoped<CenovnikServis>();
+            builder.Services.AddScoped<ICenovnikServis, CenovnikServis>();
             builder.Services.AddScoped<CenovnikStavkaServis>();
             builder.Services.AddScoped<LokacijaServis>();
             builder.Services.AddScoped<PodrucjeServis>();

--- a/src/backend/EventOrganizerAPI/Services/AktivnostiServis.cs
+++ b/src/backend/EventOrganizerAPI/Services/AktivnostiServis.cs
@@ -45,6 +45,18 @@ namespace EventOrganizerAPI.Services
         public async Task<List<Aktivnost>> VratiSve() =>
             await _aktivnosti.Find(_ => true).ToListAsync();
 
+        public async Task<List<Aktivnost>> VratiZaDogadjaj(string dogadjajId)
+        {
+            if (string.IsNullOrWhiteSpace(dogadjajId))
+            {
+                return new List<Aktivnost>();
+            }
+
+            return await _aktivnosti
+                .Find(x => x.Dogadjaj == dogadjajId)
+                .ToListAsync();
+        }
+
         public async Task<Aktivnost> VratiPoId(string id) =>
             await _aktivnosti.Find(x => x.Id == id).FirstOrDefaultAsync();
 

--- a/src/backend/EventOrganizerAPI/Services/Interfaces/IAktivnostiServis.cs
+++ b/src/backend/EventOrganizerAPI/Services/Interfaces/IAktivnostiServis.cs
@@ -9,6 +9,7 @@ namespace EventOrganizerAPI.Services.Interfaces
     {
         Task<Aktivnost> Kreiraj(KreirajAktivnostDto dto);
         Task<List<Aktivnost>> VratiSve();
+        Task<List<Aktivnost>> VratiZaDogadjaj(string dogadjajId);
         Task<Aktivnost> VratiPoId(string id);
         Task Azuriraj(AzurirajAktivnostDto dto);
         Task Obrisi(string id);

--- a/src/backend/EventOrganizerAPI/Services/Interfaces/ICenovnikServis.cs
+++ b/src/backend/EventOrganizerAPI/Services/Interfaces/ICenovnikServis.cs
@@ -9,6 +9,7 @@ namespace EventOrganizerAPI.Services.Interfaces
     {
         Task<Cenovnik> KreirajCenovnikAsync(KreirajCenovnikDto dto);
         Task<List<Cenovnik>> VratiSveCenovnikeAsync();
+        Task<List<Cenovnik>> VratiSveZaDogadjajAsync(string dogadjajId);
         Task<Cenovnik> VratiCenovnikPoIdAsync(string id);
         Task<bool> AzurirajCenovnikAsync(AzurirajCenovnikDto dto);
         Task<bool> ObrisiCenovnikAsync(string id);

--- a/src/frontend/EventOrganizerWeb/src/pages/Organizer/EventDetails.jsx
+++ b/src/frontend/EventOrganizerWeb/src/pages/Organizer/EventDetails.jsx
@@ -29,7 +29,7 @@ export default function EventDetails(){
           ticketsApi.fetchTickets(id).catch(() => []),
           daysApi.listForEventApi(id).catch(() => []),
           locationsApi.listByEvent(id).catch(() => []),
-          priceListApi.listAll().catch(() => []),
+          priceListApi.listByEvent(id).catch(() => []),
           activitiesApi.listByEvent(id).catch(() => []),
         ]);
         if (!alive) return;

--- a/src/frontend/EventOrganizerWeb/src/pages/Organizer/NewEvent/Activities.jsx
+++ b/src/frontend/EventOrganizerWeb/src/pages/Organizer/NewEvent/Activities.jsx
@@ -11,6 +11,18 @@ import * as activitiesApi from '../../../services/activitiesApi';
 
 const TIPOVI_AKTIVNOSTI = ['Koncert', 'Predavanje', 'Igrica', 'Izlozba', 'Radionica', 'Druzenje', 'Ostalo'];
 
+const TIP_LOKACIJA_COLORS = {
+  BINA: '#e11d48',
+  ULAZ: '#1d4ed8',
+  WC: '#16a34a',
+  INFO: '#9333ea',
+  VIP: '#f59e0b',
+  BAR: '#0ea5e9',
+  HRANA: '#10b981',
+  PARKING: '#64748b',
+  BEZBEDNOST: '#ef4444',
+};
+
 function normalizeDay(raw, index = 0){
   const id = raw?.Id || raw?._id || raw?.id || raw?.ID || raw?._id?.$oid;
   if (!id) return null;
@@ -30,11 +42,12 @@ function normalizeDay(raw, index = 0){
 function normalizeLocation(raw){
   const id = locationsApi.normalizeId(raw);
   if (!id) return null;
+  const rawType = String(raw?.TipLokacije || raw?.tipLokacije || raw?.Tip || raw?.tip || '').toUpperCase();
   return {
     Id: id,
     Naziv: raw?.Naziv || raw?.naziv || 'Lokacija',
     Tip: raw?.TipLokacije || raw?.tipLokacije || raw?.Tip || raw?.tip || '',
-    Color: raw?.HEXboja || raw?.hexBoja || raw?.Boja || '#1f6feb',
+    Color: TIP_LOKACIJA_COLORS[rawType] || raw?.HEXboja || raw?.hexBoja || raw?.Boja || '#1f6feb',
   };
 }
 

--- a/src/frontend/EventOrganizerWeb/src/pages/Organizer/NewEvent/NewEvent.jsx
+++ b/src/frontend/EventOrganizerWeb/src/pages/Organizer/NewEvent/NewEvent.jsx
@@ -43,7 +43,7 @@ export default function NewEvent(){
       ticketsApi.fetchTickets(id).catch(() => []),
       daysApi.listForEventApi(id).catch(() => []),
       locationsApi.listByEvent(id).catch(() => []),
-      priceListApi.listAll().catch(() => []),
+      priceListApi.listByEvent(id).catch(() => []),
       activitiesApi.listByEvent(id).catch(() => []),
     ]);
 

--- a/src/frontend/EventOrganizerWeb/src/pages/Organizer/NewEvent/PriceList.jsx
+++ b/src/frontend/EventOrganizerWeb/src/pages/Organizer/NewEvent/PriceList.jsx
@@ -125,7 +125,7 @@ export default function PriceList({ eventId }){
     try {
       const [locsRaw, lists] = await Promise.all([
         locationsApi.listByEvent(eventId).catch(() => []),
-        priceListApi.listAll().catch(() => []),
+        priceListApi.listByEvent(eventId).catch(() => []),
       ]);
       if (shouldStop()) return;
 
@@ -144,6 +144,7 @@ export default function PriceList({ eventId }){
           Id: pl?.Id || pl?.id || pl?._id || '',
           LokacijaId: pl?.LokacijaId || pl?.lokacijaId || '',
           Naziv: pl?.Naziv || pl?.naziv || '',
+          DogadjajId: pl?.DogadjajId || pl?.dogadjajId || eventId,
         }))
         .filter((pl) => {
           if (locationIds.size === 0) return true;
@@ -405,6 +406,7 @@ export default function PriceList({ eventId }){
       const payload = {
         Naziv: name.trim(),
         LokacijaId: locationId,
+        DogadjajId: eventId,
         StavkeIds: [],
       };
       const created = await priceListApi.createPriceList(payload);
@@ -433,6 +435,7 @@ export default function PriceList({ eventId }){
       await priceListApi.updatePriceList(createdId, {
         Naziv: name.trim(),
         LokacijaId: locationId,
+        DogadjajId: eventId,
         StavkeIds: createdIds,
       }).catch(() => {});
 
@@ -521,6 +524,7 @@ export default function PriceList({ eventId }){
       await priceListApi.updatePriceList(currentListId, {
         Naziv: name.trim(),
         LokacijaId: locationId,
+        DogadjajId: eventId,
         StavkeIds: idsForList,
       }).catch(() => {});
 

--- a/src/frontend/EventOrganizerWeb/src/services/activitiesApi.js
+++ b/src/frontend/EventOrganizerWeb/src/services/activitiesApi.js
@@ -18,8 +18,9 @@ export async function listAll(){
 
 export async function listByEvent(eventId){
   if(!eventId) return [];
-  const all = await listAll();
-  return all.filter(item => matchesEvent(item, eventId));
+  const { data } = await api.get(`aktivnosti/dogadjaj/${eventId}`);
+  const list = Array.isArray(data) ? data : [];
+  return list.filter(item => matchesEvent(item, eventId));
 }
 
 export async function create(dto){

--- a/src/frontend/EventOrganizerWeb/src/services/areasApi.js
+++ b/src/frontend/EventOrganizerWeb/src/services/areasApi.js
@@ -34,7 +34,7 @@ export async function remove(id){
 /** Pomoćno: filtriranja na klijentu */
 export async function getForEvent(eventId){
   const all = await getAll();
-  return all.filter(a => a?.DogadjajId === eventId);
+  return all.filter(a => String(a?.DogadjajId ?? a?.dogadjajId ?? '') === String(eventId));
 }
 export async function getForDay(dayId){
   const all = await getAll();

--- a/src/frontend/EventOrganizerWeb/src/services/priceListApi.js
+++ b/src/frontend/EventOrganizerWeb/src/services/priceListApi.js
@@ -13,6 +13,12 @@ export async function listAll(){
   return Array.isArray(data) ? data : [];
 }
 
+export async function listByEvent(eventId){
+  if(!eventId) return [];
+  const { data } = await api.get(`${PRICE_LIST_BASE}/dogadjaj/${eventId}`);
+  return Array.isArray(data) ? data : [];
+}
+
 export async function getById(id){
   if(!id) return null;
   const { data } = await api.get(`${PRICE_LIST_BASE}/vrati-po-id/${id}`);
@@ -23,6 +29,7 @@ export async function createPriceList(dto){
   const payload = {
     Naziv: dto?.Naziv || dto?.naziv || '',
     LokacijaId: dto?.LokacijaId || dto?.lokacijaId || '',
+    DogadjajId: dto?.DogadjajId || dto?.dogadjajId || '',
     StavkeIds: Array.isArray(dto?.StavkeIds) ? dto.StavkeIds : [],
   };
   const { data } = await api.post(`${PRICE_LIST_BASE}/kreiraj`, payload);
@@ -34,6 +41,7 @@ export async function updatePriceList(id, dto){
     Id: id,
     Naziv: dto?.Naziv || dto?.naziv,
     LokacijaId: dto?.LokacijaId || dto?.lokacijaId,
+    DogadjajId: dto?.DogadjajId || dto?.dogadjajId,
     StavkeIds: Array.isArray(dto?.StavkeIds) ? dto.StavkeIds : dto?.stavkeIds,
   };
   const { data } = await api.put(`${PRICE_LIST_BASE}/azuriraj/${id}`, payload);

--- a/src/frontend/EventOrganizerWeb/src/styles/NewEvent/locations.css
+++ b/src/frontend/EventOrganizerWeb/src/styles/NewEvent/locations.css
@@ -21,6 +21,18 @@
   align-items: start;
 }
 
+.color-row.readonly {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.color-row.readonly .color-code {
+  font-family: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+  font-size: 0.95rem;
+  color: var(--ne-text-muted);
+}
+
 @media (max-width: 1100px) {
   .loc-res-wrap {
     grid-template-columns: 1fr;


### PR DESCRIPTION
## Summary
- add DogadjajId support to price list models and expose event-scoped API endpoints for price lists and activities
- update frontend data fetching to use the new event-filtered endpoints and ensure price list operations include the current event draft id
- derive location colors from their type, remove manual color selection, and tighten client-side filtering of areas and related data

## Testing
- dotnet test src/backend/EventOrganizerAPI/EventOrganizerAPI.sln *(fails: dotnet CLI not available in container)*
- CI=true npm test -- --watch=false --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_e_690d1fcf6748832aba02e6d2c5b55ab3