### PR TITLE
Fix location update API and refine organizer forms

### DIFF
--- a/src/frontend/EventOrganizerWeb/src/pages/Organizer/NewEvent/Activities.jsx
+++ b/src/frontend/EventOrganizerWeb/src/pages/Organizer/NewEvent/Activities.jsx
@@ -270,6 +270,8 @@ export default function Activities({ eventId }){
     });
   }, [activities, dayById, locationById]);
 
+  const totalScheduleEntries = scheduleRows.length;
+
   const onField = (field, value) => {
     setForm(prev => ({ ...prev, [field]: value }));
   };
@@ -391,6 +393,7 @@ export default function Activities({ eventId }){
         saving ? { label: 'Čuvanje...', tone: 'info' } : null,
         !hasEvent ? { label: 'Draft nije kreiran', tone: 'warning' } : null,
         { label: `Aktivnosti: ${activities.length || 0}` },
+        { label: `Raspored: ${totalScheduleEntries}` },
       ].filter(Boolean)}
     >
       {!hasEvent && (
@@ -512,54 +515,56 @@ export default function Activities({ eventId }){
           </div>
         </form>
 
-        <div className="act-schedule">
-          <h3>Raspored</h3>
-          <table className="act-table">
-            <thead>
-              <tr>
-                <th>Dan</th>
-                <th>Lokacija</th>
-                <th>Aktivnost</th>
-                <th>Vreme</th>
-                <th>Tip</th>
-                <th>Akcije</th>
-              </tr>
-            </thead>
-            <tbody>
-              {scheduleRows.length === 0 && (
+        <form className="act-schedule" onSubmit={(e) => e.preventDefault()} aria-label="Pregled rasporeda aktivnosti">
+          <fieldset className="act-schedule-fieldset">
+            <legend>Raspored</legend>
+            <table className="act-table">
+              <thead>
                 <tr>
-                  <td colSpan={6} className="act-empty">Još uvek nema unetih aktivnosti.</td>
+                  <th>Dan</th>
+                  <th>Lokacija</th>
+                  <th>Aktivnost</th>
+                  <th>Vreme</th>
+                  <th>Tip</th>
+                  <th>Akcije</th>
                 </tr>
-              )}
-              {scheduleRows.map(row => (
-                <tr key={row.Id}>
-                  <td>
-                    <div className="act-cell-main">{row.DayName}</div>
-                    <div className="act-cell-sub">{row.DayLabel}</div>
-                  </td>
-                  <td>
-                    <div className="act-cell-main">{row.LocationName}</div>
-                    <div className="act-cell-sub">{row.LocationTip}</div>
-                  </td>
-                  <td>
-                    <div className="act-cell-main">{row.Naziv}</div>
-                    <div className="act-cell-sub">{row.Opis || 'Bez opisa'}</div>
-                  </td>
-                  <td>
-                    <div className="act-cell-main">{row.StartLabel} – {row.EndLabel}</div>
-                  </td>
-                  <td>{row.Tip}</td>
-                  <td>
-                    <div className="act-row-actions">
-                      <button className="act-btn act-secondary" type="button" onClick={() => handleEdit(row)} disabled={saving}>Uredi</button>
-                      <button className="act-btn act-danger" type="button" onClick={() => handleDelete(row)} disabled={saving}>Obriši</button>
-                    </div>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+              </thead>
+              <tbody>
+                {scheduleRows.length === 0 && (
+                  <tr>
+                    <td colSpan={6} className="act-empty">Još uvek nema unetih aktivnosti.</td>
+                  </tr>
+                )}
+                {scheduleRows.map(row => (
+                  <tr key={row.Id}>
+                    <td>
+                      <div className="act-cell-main">{row.DayName}</div>
+                      <div className="act-cell-sub">{row.DayLabel}</div>
+                    </td>
+                    <td>
+                      <div className="act-cell-main">{row.LocationName}</div>
+                      <div className="act-cell-sub">{row.LocationTip}</div>
+                    </td>
+                    <td>
+                      <div className="act-cell-main">{row.Naziv}</div>
+                      <div className="act-cell-sub">{row.Opis || 'Bez opisa'}</div>
+                    </td>
+                    <td>
+                      <div className="act-cell-main">{row.StartLabel} – {row.EndLabel}</div>
+                    </td>
+                    <td>{row.Tip}</td>
+                    <td>
+                      <div className="act-row-actions">
+                        <button className="act-btn act-secondary" type="button" onClick={() => handleEdit(row)} disabled={saving}>Uredi</button>
+                        <button className="act-btn act-danger" type="button" onClick={() => handleDelete(row)} disabled={saving}>Obriši</button>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </fieldset>
+        </form>
       </div>
     </Section>
   );

--- a/src/frontend/EventOrganizerWeb/src/pages/Organizer/NewEvent/PriceList.jsx
+++ b/src/frontend/EventOrganizerWeb/src/pages/Organizer/NewEvent/PriceList.jsx
@@ -561,33 +561,6 @@ export default function PriceList({ eventId }){
     setMode('editing');
   }, [currentListId]);
 
-  const renderControls = () => {
-    if (mode === 'creating'){
-      return (
-        <div className="pl-controls">
-          <button className="pl-btn" onClick={handleSaveNew} disabled={saving}>Sačuvaj</button>
-          <button className="pl-btn pl-secondary" onClick={handleCancel} disabled={saving}>Otkaži</button>
-        </div>
-      );
-    }
-    if (mode === 'editing'){
-      return (
-        <div className="pl-controls">
-          <button className="pl-btn" onClick={handleSaveChanges} disabled={saving}>Sačuvaj izmene</button>
-          <button className="pl-btn pl-secondary" onClick={handleCancel} disabled={saving}>Odustani</button>
-        </div>
-      );
-    }
-    if (mode === 'view'){
-      return null;
-    }
-    return (
-      <div className="pl-controls">
-        <button className="pl-btn" onClick={startNew} disabled={!hasEvent || loading || saving}>Dodaj cenovnik</button>
-      </div>
-    );
-  };
-
   const locationNameById = useCallback((id) => {
     const match = (locations || []).find((loc) => String(locationsApi.normalizeId(loc)) === String(id));
     return match?.Naziv || match?.naziv || 'Lokacija';
@@ -599,10 +572,24 @@ export default function PriceList({ eventId }){
     return existingLists.length ? { label: 'Postojeći cenovnik', tone: 'success' } : { label: 'Nema cenovnika', tone: 'warning' };
   })();
 
+  const handleMetadataSubmit = useCallback((e) => {
+    e?.preventDefault();
+    if (mode === 'creating'){
+      handleSaveNew();
+      return;
+    }
+    if (mode === 'editing'){
+      handleSaveChanges();
+    }
+  }, [handleSaveNew, handleSaveChanges, mode]);
+
+  const totalLists = existingLists.length || 0;
+
   const headerBadges = [
     loading ? { label: 'Učitavanje...', tone: 'info' } : null,
     saving ? { label: 'Čuvanje...', tone: 'info' } : null,
     modeBadge,
+    { label: `Cenovnici: ${totalLists}` },
     { label: `Stavki: ${items.length || 0}` },
   ].filter(Boolean);
 
@@ -704,35 +691,55 @@ export default function PriceList({ eventId }){
         </div>
       ) : (
         <>
-          <div className="pl-meta">
-            <div className="pl-field">
-              <label>Naziv cenovnika</label>
-              <input
-                className="pl-input"
-                value={name}
-                onChange={(e) => setName(e.target.value)}
-                disabled={!isEditable}
-                placeholder="npr. Pića"
-              />
+          <form className="pl-meta" onSubmit={handleMetadataSubmit}>
+            <fieldset className="pl-meta-fieldset" disabled={!isEditable}>
+              <legend>Osnovne informacije</legend>
+              <div className="pl-field">
+                <label htmlFor="pl-name">Naziv cenovnika</label>
+                <input
+                  id="pl-name"
+                  className="pl-input"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  placeholder="npr. Pića"
+                />
+              </div>
+              <div className="pl-field">
+                <label htmlFor="pl-location">Lokacija</label>
+                <select
+                  id="pl-location"
+                  className="pl-select"
+                  value={locationId}
+                  onChange={(e) => setLocationId(e.target.value)}
+                >
+                  <option value="">-- Odaberi lokaciju --</option>
+                  {locations.map((loc) => {
+                    const id = String(locationsApi.normalizeId(loc) || '');
+                    return (
+                      <option key={id} value={id}>{loc?.Naziv || loc?.naziv || 'Lokacija'}</option>
+                    );
+                  })}
+                </select>
+              </div>
+            </fieldset>
+            <div className="pl-controls">
+              {mode === 'creating' && (
+                <>
+                  <button className="pl-btn" type="submit" disabled={saving}>Sačuvaj</button>
+                  <button className="pl-btn pl-secondary" type="button" onClick={handleCancel} disabled={saving}>Otkaži</button>
+                </>
+              )}
+              {mode === 'editing' && (
+                <>
+                  <button className="pl-btn" type="submit" disabled={saving}>Sačuvaj izmene</button>
+                  <button className="pl-btn pl-secondary" type="button" onClick={handleCancel} disabled={saving}>Odustani</button>
+                </>
+              )}
+              {mode === 'idle' && (
+                <button className="pl-btn" type="button" onClick={startNew} disabled={!hasEvent || loading || saving}>Dodaj cenovnik</button>
+              )}
             </div>
-            <div className="pl-field">
-              <label>Lokacija</label>
-              <select
-                className="pl-select"
-                value={locationId}
-                onChange={(e) => setLocationId(e.target.value)}
-                disabled={!isEditable}
-              >
-                <option value="">-- Odaberi lokaciju --</option>
-                {locations.map((loc) => {
-                  const id = String(locationsApi.normalizeId(loc) || '');
-                  return (
-                    <option key={id} value={id}>{loc?.Naziv || loc?.naziv || 'Lokacija'}</option>
-                  );
-                })}
-              </select>
-            </div>
-          </div>
+          </form>
 
           <div className="pl-content">
             <div className="pl-form-wrap">

--- a/src/frontend/EventOrganizerWeb/src/pages/Organizer/NewEvent/Tickets.jsx
+++ b/src/frontend/EventOrganizerWeb/src/pages/Organizer/NewEvent/Tickets.jsx
@@ -99,7 +99,7 @@ export default function Tickets({ eventId, initialCapacity, initialInfinite }){
   }, [eventId, initialCapacity, initialInfinite]);
 
   useEffect(() => {
-    if (!eventId || infinite !== true) return;
+    if (infinite !== true) return;
     let autoAlready = false;
     let draftTicket = null;
     setTickets(prev => {
@@ -110,6 +110,7 @@ export default function Tickets({ eventId, initialCapacity, initialInfinite }){
       }
       draftTicket = {
         localId: `auto-${Math.random().toString(36).slice(2)}`,
+        Id: null,
         Naziv: 'Ulaznica',
         Tip: 'besplatna',
         Cena: 0,
@@ -121,7 +122,7 @@ export default function Tickets({ eventId, initialCapacity, initialInfinite }){
       return [draftTicket, ...prev];
     });
 
-    if (autoAlready || !draftTicket) return;
+    if (autoAlready || !draftTicket || !eventId) return;
 
     (async () => {
       try{

--- a/src/frontend/EventOrganizerWeb/src/services/locationsApi.js
+++ b/src/frontend/EventOrganizerWeb/src/services/locationsApi.js
@@ -52,7 +52,7 @@ export async function update(id, dto) {
     TipLokacije: dto.TipLokacije == null ? undefined : String(dto.TipLokacije),
     Resursi: Array.isArray(dto.Resursi) ? dto.Resursi : undefined,
   };
-  const { data } = await api.put('lokacije/azuriraj', payload);
+  const { data } = await api.put(`lokacije/azuriraj/${id}`, payload);
   return data;
 }
 

--- a/src/frontend/EventOrganizerWeb/src/styles/NewEvent/activities.css
+++ b/src/frontend/EventOrganizerWeb/src/styles/NewEvent/activities.css
@@ -21,7 +21,7 @@
 }
 
 .act-form h3,
-.act-schedule h3 {
+.act-schedule-fieldset legend {
   font-size: 1.1rem;
   font-weight: 600;
   margin-bottom: 12px;
@@ -138,6 +138,13 @@
   border: 1px solid var(--ne-border);
   padding: 18px;
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
+}
+
+.act-schedule-fieldset {
+  border: none;
+  padding: 0;
+  margin: 0;
+  min-width: 0;
 }
 
 .act-table {

--- a/src/frontend/EventOrganizerWeb/src/styles/NewEvent/pricelist.css
+++ b/src/frontend/EventOrganizerWeb/src/styles/NewEvent/pricelist.css
@@ -32,6 +32,30 @@
   margin-bottom: 20px;
 }
 
+.pl-meta-fieldset {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  align-items: flex-end;
+  border: 1px solid var(--ne-border);
+  border-radius: 16px;
+  padding: 16px;
+  margin: 0;
+  min-width: 220px;
+  background: var(--ne-surface-alt);
+}
+
+.pl-meta-fieldset[disabled] {
+  opacity: 0.75;
+}
+
+.pl-meta-fieldset legend {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--ne-text-muted);
+  padding: 0 8px;
+}
+
 .pl-meta .pl-field {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- fix the organizer location update client to use the API route that includes the location id
- restructure price list editing into a parent form with grouped metadata controls and show list counters in the header
- expose schedule statistics and wrap the timetable in its own sub-form, plus ensure auto free tickets appear even before an event id exists

## Testing
- CI=true npm test -- --watchAll=false --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_e_690d36988078832a89bad258355d9c2f