### PR TITLE
Add schedule management for event activities

### DIFF
--- a/src/backend/EventOrganizerAPI/Controllers/RasporedController.cs
+++ b/src/backend/EventOrganizerAPI/Controllers/RasporedController.cs
@@ -30,6 +30,13 @@ namespace EventOrganizerAPI.Controllers
             return Ok(rezultat);
         }
 
+        [HttpGet("dogadjaj/{dogadjajId}")]
+        public async Task<IActionResult> VratiZaDogadjaj(string dogadjajId)
+        {
+            var rezultat = await _servis.VratiZaDogadjaj(dogadjajId);
+            return Ok(rezultat);
+        }
+
         [HttpGet("vrati-po-id/{id}")]
         public async Task<IActionResult> VratiPoId(string id)
         {

--- a/src/backend/EventOrganizerAPI/DTOs/Dogadjaj/AzurirajDogadjajDto.cs
+++ b/src/backend/EventOrganizerAPI/DTOs/Dogadjaj/AzurirajDogadjajDto.cs
@@ -21,6 +21,7 @@ namespace EventOrganizerAPI.DTOs.Dogadjaj
         public List<string>? Dani {  get; set; }
         public List<string>? Cenovnici { get; set; }
         public List<string>? Aktivnosti { get; set; }
+        public List<string>? Rasporedi { get; set; }
     }
 
 }

--- a/src/backend/EventOrganizerAPI/DTOs/Dogadjaj/KreirajDogadjajDto.cs
+++ b/src/backend/EventOrganizerAPI/DTOs/Dogadjaj/KreirajDogadjajDto.cs
@@ -20,5 +20,6 @@ namespace EventOrganizerAPI.DTOs.Dogadjaj
         public List<string> Resursi { get; set; } = new List<string>();
         public List<string> Cenovnici { get; set; } = new List<string>();
         public List<string> Aktivnosti { get; set; } = new List<string>();
+        public List<string> Rasporedi { get; set; } = new List<string>();
     }
 }

--- a/src/backend/EventOrganizerAPI/DTOs/Dogadjaj/PrikaziDogadjajDto.cs
+++ b/src/backend/EventOrganizerAPI/DTOs/Dogadjaj/PrikaziDogadjajDto.cs
@@ -17,6 +17,7 @@ namespace EventOrganizerAPI.Dtos.Dogadjaj
         public List<string> Dani { get; set; } = new List<string>();
         public List<string> Cenovnici { get; set; } = new List<string>();
         public List<string> Aktivnosti { get; set; } = new List<string>();
+        public List<string> Rasporedi { get; set; } = new List<string>();
         public List<string> Prijavljeni { get; set; } = new List<string>();
         public List<string> Tagovi { get; set; } = new List<string>();
         public List<string> Notifikacije { get; set; } = new List<string>();

--- a/src/backend/EventOrganizerAPI/DTOs/RasporedAktivnosti/AzurirajAktivnostDto.cs
+++ b/src/backend/EventOrganizerAPI/DTOs/RasporedAktivnosti/AzurirajAktivnostDto.cs
@@ -14,5 +14,6 @@ namespace EventOrganizerAPI.DTOs.RasporedAktivnosti
         public string? Dan { get; set; }
         public string? Dogadjaj { get; set; }
         public string? Tip { get; set; }
+        public string? RasporedId { get; set; }
     }
 }

--- a/src/backend/EventOrganizerAPI/DTOs/RasporedAktivnosti/KreirajAktivnostDto.cs
+++ b/src/backend/EventOrganizerAPI/DTOs/RasporedAktivnosti/KreirajAktivnostDto.cs
@@ -13,5 +13,6 @@ namespace EventOrganizerAPI.DTOs.RasporedAktivnosti
         public string Dan { get; set; }
         public string Dogadjaj { get; set; }
         public string Tip { get; set; }
+        public string RasporedId { get; set; }
     }
 }

--- a/src/backend/EventOrganizerAPI/DTOs/RasporedAktivnosti/PrikaziAktivnostDto.cs
+++ b/src/backend/EventOrganizerAPI/DTOs/RasporedAktivnosti/PrikaziAktivnostDto.cs
@@ -15,6 +15,7 @@ namespace EventOrganizerAPI.DTOs.RasporedAktivnosti
         public string Dan { get; set; }
         public string Dogadjaj { get; set; }
         public string Tip { get; set; }
+        public string RasporedId { get; set; }
         public List<string> Notifikacije { get; set; }
         public List<string> Resursi { get; set; }
     }

--- a/src/backend/EventOrganizerAPI/Models/Aktivnost.cs
+++ b/src/backend/EventOrganizerAPI/Models/Aktivnost.cs
@@ -30,6 +30,9 @@ namespace EventOrganizerAPI.Models
         public string Tip { get; set; }
 
         [BsonRepresentation(BsonType.ObjectId)]
+        public string RasporedId { get; set; }
+
+        [BsonRepresentation(BsonType.ObjectId)]
         public List<string> Notifikacije { get; set; } = new();
 
         [BsonRepresentation(BsonType.ObjectId)]

--- a/src/backend/EventOrganizerAPI/Models/Dogadjaj.cs
+++ b/src/backend/EventOrganizerAPI/Models/Dogadjaj.cs
@@ -48,6 +48,10 @@ namespace EventOrganizerAPI.Models
         [BsonRepresentation(BsonType.ObjectId)]
         public List<string> Aktivnosti { get; set; } = new List<string>();
 
+        [BsonElement("rasporedi")]
+        [BsonRepresentation(BsonType.ObjectId)]
+        public List<string> Rasporedi { get; set; } = new List<string>();
+
         [BsonElement("prijavljeni")]
         public List<string> Prijavljeni { get; set; } = new List<string>();
 

--- a/src/backend/EventOrganizerAPI/Services/AktivnostiServis.cs
+++ b/src/backend/EventOrganizerAPI/Services/AktivnostiServis.cs
@@ -2,6 +2,7 @@ using EventOrganizerAPI.Models;
 using EventOrganizerAPI.DTOs.RasporedAktivnosti;
 using EventOrganizerAPI.Services.Interfaces;
 using MongoDB.Driver;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -11,11 +12,13 @@ namespace EventOrganizerAPI.Services
     {
         private readonly IMongoCollection<Aktivnost> _aktivnosti;
         private readonly IMongoCollection<DanDogadjaja> _dani;
+        private readonly IMongoCollection<Raspored> _rasporedi;
 
         public AktivnostiServis(IMongoDatabase db)
         {
             _aktivnosti = db.GetCollection<Aktivnost>("Aktivnosti");
             _dani = db.GetCollection<DanDogadjaja>("Dani");
+            _rasporedi = db.GetCollection<Raspored>("Rasporedi");
         }
 
         public async Task<Aktivnost> Kreiraj(KreirajAktivnostDto dto)
@@ -29,7 +32,8 @@ namespace EventOrganizerAPI.Services
                 Lokacija = dto.Lokacija,
                 Dan = dto.Dan,
                 Dogadjaj = dto.Dogadjaj,
-                Tip = dto.Tip
+                Tip = dto.Tip,
+                RasporedId = dto.RasporedId
             };
 
             await _aktivnosti.InsertOneAsync(a);
@@ -38,6 +42,13 @@ namespace EventOrganizerAPI.Services
             var update = Builders<DanDogadjaja>.Update.Push(d=> d.Aktivnosti,a.Id);
 
             await _dani.UpdateOneAsync(filter, update);
+
+            if (!string.IsNullOrWhiteSpace(dto.RasporedId))
+            {
+                var rasporedFilter = Builders<Raspored>.Filter.Eq(r => r.Id, dto.RasporedId);
+                var rasporedUpdate = Builders<Raspored>.Update.AddToSet(r => r.Aktivnosti, a.Id);
+                await _rasporedi.UpdateOneAsync(rasporedFilter, rasporedUpdate);
+            }
 
             return a;
         }
@@ -62,29 +73,108 @@ namespace EventOrganizerAPI.Services
 
         public async Task Azuriraj(AzurirajAktivnostDto dto)
         {
-            var update = Builders<Aktivnost>.Update.Combine();
+            var existing = await _aktivnosti.Find(x => x.Id == dto.Id).FirstOrDefaultAsync();
+            if (existing == null)
+            {
+                return;
+            }
+
+            var updates = new List<UpdateDefinition<Aktivnost>>();
 
             if (dto.Naziv != null)
-                update = update.Set(x => x.Naziv, dto.Naziv);
+                updates.Add(Builders<Aktivnost>.Update.Set(x => x.Naziv, dto.Naziv));
             if (dto.Opis != null)
-                update = update.Set(x => x.Opis, dto.Opis);
+                updates.Add(Builders<Aktivnost>.Update.Set(x => x.Opis, dto.Opis));
             if (dto.DatumVremePocetka.HasValue)
-                update = update.Set(x => x.DatumVremePocetka, dto.DatumVremePocetka.Value);
+                updates.Add(Builders<Aktivnost>.Update.Set(x => x.DatumVremePocetka, dto.DatumVremePocetka.Value));
             if (dto.DatumVremeKraja.HasValue)
-                update = update.Set(x => x.DatumVremeKraja, dto.DatumVremeKraja.Value);
+                updates.Add(Builders<Aktivnost>.Update.Set(x => x.DatumVremeKraja, dto.DatumVremeKraja.Value));
             if (dto.Lokacija != null)
-                update = update.Set(x => x.Lokacija, dto.Lokacija);
+                updates.Add(Builders<Aktivnost>.Update.Set(x => x.Lokacija, dto.Lokacija));
             if (dto.Dan != null)
-                update = update.Set(x => x.Dan, dto.Dan);
+            {
+                if (string.IsNullOrWhiteSpace(dto.Dan))
+                    updates.Add(Builders<Aktivnost>.Update.Unset(x => x.Dan));
+                else
+                    updates.Add(Builders<Aktivnost>.Update.Set(x => x.Dan, dto.Dan));
+            }
             if (dto.Dogadjaj != null)
-                update = update.Set(x => x.Dogadjaj, dto.Dogadjaj);
+                updates.Add(Builders<Aktivnost>.Update.Set(x => x.Dogadjaj, dto.Dogadjaj));
             if (dto.Tip != null)
-                update = update.Set(x => x.Tip, dto.Tip);
+                updates.Add(Builders<Aktivnost>.Update.Set(x => x.Tip, dto.Tip));
+            if (dto.RasporedId != null)
+            {
+                if (string.IsNullOrWhiteSpace(dto.RasporedId))
+                    updates.Add(Builders<Aktivnost>.Update.Unset(x => x.RasporedId));
+                else
+                    updates.Add(Builders<Aktivnost>.Update.Set(x => x.RasporedId, dto.RasporedId));
+            }
 
-            await _aktivnosti.UpdateOneAsync(x => x.Id == dto.Id, update);
+            if (updates.Count > 0)
+            {
+                var combined = Builders<Aktivnost>.Update.Combine(updates);
+                await _aktivnosti.UpdateOneAsync(x => x.Id == dto.Id, combined);
+            }
+
+            if (dto.Dan != null && dto.Dan != existing.Dan)
+            {
+                if (!string.IsNullOrEmpty(existing.Dan))
+                {
+                    var oldDayFilter = Builders<DanDogadjaja>.Filter.Eq(x => x.Id, existing.Dan);
+                    var oldDayUpdate = Builders<DanDogadjaja>.Update.Pull(x => x.Aktivnosti, existing.Id);
+                    await _dani.UpdateOneAsync(oldDayFilter, oldDayUpdate);
+                }
+
+                if (!string.IsNullOrWhiteSpace(dto.Dan))
+                {
+                    var newDayFilter = Builders<DanDogadjaja>.Filter.Eq(x => x.Id, dto.Dan);
+                    var newDayUpdate = Builders<DanDogadjaja>.Update.AddToSet(x => x.Aktivnosti, existing.Id);
+                    await _dani.UpdateOneAsync(newDayFilter, newDayUpdate);
+                }
+            }
+
+            if (dto.RasporedId != null && dto.RasporedId != existing.RasporedId)
+            {
+                if (!string.IsNullOrEmpty(existing.RasporedId))
+                {
+                    var oldScheduleFilter = Builders<Raspored>.Filter.Eq(x => x.Id, existing.RasporedId);
+                    var oldScheduleUpdate = Builders<Raspored>.Update.Pull(x => x.Aktivnosti, existing.Id);
+                    await _rasporedi.UpdateOneAsync(oldScheduleFilter, oldScheduleUpdate);
+                }
+
+                if (!string.IsNullOrWhiteSpace(dto.RasporedId))
+                {
+                    var newScheduleFilter = Builders<Raspored>.Filter.Eq(x => x.Id, dto.RasporedId);
+                    var newScheduleUpdate = Builders<Raspored>.Update.AddToSet(x => x.Aktivnosti, existing.Id);
+                    await _rasporedi.UpdateOneAsync(newScheduleFilter, newScheduleUpdate);
+                }
+            }
         }
 
-        public async Task Obrisi(string id) =>
+        public async Task Obrisi(string id)
+        {
+            var existing = await _aktivnosti.Find(x => x.Id == id).FirstOrDefaultAsync();
+
             await _aktivnosti.DeleteOneAsync(x => x.Id == id);
+
+            if (existing == null)
+            {
+                return;
+            }
+
+            if (!string.IsNullOrEmpty(existing.Dan))
+            {
+                var dayFilter = Builders<DanDogadjaja>.Filter.Eq(x => x.Id, existing.Dan);
+                var dayUpdate = Builders<DanDogadjaja>.Update.Pull(x => x.Aktivnosti, existing.Id);
+                await _dani.UpdateOneAsync(dayFilter, dayUpdate);
+            }
+
+            if (!string.IsNullOrEmpty(existing.RasporedId))
+            {
+                var scheduleFilter = Builders<Raspored>.Filter.Eq(x => x.Id, existing.RasporedId);
+                var scheduleUpdate = Builders<Raspored>.Update.Pull(x => x.Aktivnosti, existing.Id);
+                await _rasporedi.UpdateOneAsync(scheduleFilter, scheduleUpdate);
+            }
+        }
     }
 }

--- a/src/backend/EventOrganizerAPI/Services/DogadjajServis.cs
+++ b/src/backend/EventOrganizerAPI/Services/DogadjajServis.cs
@@ -43,6 +43,7 @@ namespace EventOrganizerAPI.Services
                 Dani = new List<string>(),
                 Cenovnici = dto.Cenovnici ?? new List<string>(),
                 Aktivnosti = dto.Aktivnosti ?? new List<string>(),
+                Rasporedi = dto.Rasporedi ?? new List<string>(),
                 Prijavljeni = new List<string>(),
                 Tagovi = dto.Tagovi,
                 Notifikacije = new List<string>(),
@@ -81,6 +82,7 @@ namespace EventOrganizerAPI.Services
                 Dani = d.Dani,
                 Cenovnici = d.Cenovnici,
                 Aktivnosti = d.Aktivnosti,
+                Rasporedi = d.Rasporedi,
                 Prijavljeni = d.Prijavljeni,
                 Tagovi = d.Tagovi,
                 Notifikacije = d.Notifikacije,
@@ -128,6 +130,9 @@ namespace EventOrganizerAPI.Services
 
             if (dto.Aktivnosti != null)
                 update = update.Set(d => d.Aktivnosti, dto.Aktivnosti);
+
+            if (dto.Rasporedi != null)
+                update = update.Set(d => d.Rasporedi, dto.Rasporedi);
 
             await _dogadjaji.UpdateOneAsync(filter, update);
         }

--- a/src/backend/EventOrganizerAPI/Services/Interfaces/IRasporedServis.cs
+++ b/src/backend/EventOrganizerAPI/Services/Interfaces/IRasporedServis.cs
@@ -9,6 +9,7 @@ namespace EventOrganizerAPI.Services.Interfaces
     {
         Task<Raspored> Kreiraj(KreirajRasporedDto dto);
         Task<List<Raspored>> VratiSve();
+        Task<List<Raspored>> VratiZaDogadjaj(string dogadjajId);
         Task<Raspored> VratiPoId(string id);
         Task Azuriraj(AzurirajRasporedDto dto);
         Task Obrisi(string id);

--- a/src/backend/EventOrganizerAPI/Services/RasporedServis.cs
+++ b/src/backend/EventOrganizerAPI/Services/RasporedServis.cs
@@ -2,6 +2,7 @@ using EventOrganizerAPI.Models;
 using EventOrganizerAPI.DTOs.RasporedAktivnosti;
 using EventOrganizerAPI.Services.Interfaces;
 using MongoDB.Driver;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -10,10 +11,14 @@ namespace EventOrganizerAPI.Services
     public class RasporedServis : IRasporedServis
     {
         private readonly IMongoCollection<Raspored> _rasporedi;
+        private readonly IMongoCollection<Dogadjaj> _dogadjaji;
+        private readonly IMongoCollection<Aktivnost> _aktivnosti;
 
         public RasporedServis(IMongoDatabase db)
         {
             _rasporedi = db.GetCollection<Raspored>("Rasporedi");
+            _dogadjaji = db.GetCollection<Dogadjaj>("Dogadjaji");
+            _aktivnosti = db.GetCollection<Aktivnost>("Aktivnosti");
         }
 
         public async Task<Raspored> Kreiraj(KreirajRasporedDto dto)
@@ -29,17 +34,43 @@ namespace EventOrganizerAPI.Services
             };
 
             await _rasporedi.InsertOneAsync(r);
+
+            if (!string.IsNullOrWhiteSpace(dto.DogadjajId))
+            {
+                var filter = Builders<Dogadjaj>.Filter.Eq(x => x.Id, dto.DogadjajId);
+                var update = Builders<Dogadjaj>.Update.AddToSet(x => x.Rasporedi, r.Id);
+                await _dogadjaji.UpdateOneAsync(filter, update);
+            }
+
             return r;
         }
 
         public async Task<List<Raspored>> VratiSve() =>
             await _rasporedi.Find(_ => true).ToListAsync();
 
+        public async Task<List<Raspored>> VratiZaDogadjaj(string dogadjajId)
+        {
+            if (string.IsNullOrWhiteSpace(dogadjajId))
+            {
+                return new List<Raspored>();
+            }
+
+            return await _rasporedi
+                .Find(x => x.DogadjajId == dogadjajId)
+                .ToListAsync();
+        }
+
         public async Task<Raspored> VratiPoId(string id) =>
             await _rasporedi.Find(x => x.Id == id).FirstOrDefaultAsync();
 
         public async Task Azuriraj(AzurirajRasporedDto dto)
         {
+            var existing = await _rasporedi.Find(x => x.Id == dto.Id).FirstOrDefaultAsync();
+            if (existing == null)
+            {
+                return;
+            }
+
             var updateBuilder = Builders<Raspored>.Update;
             var updates = new List<UpdateDefinition<Raspored>>();
 
@@ -58,9 +89,48 @@ namespace EventOrganizerAPI.Services
 
             var combined = updateBuilder.Combine(updates);
             await _rasporedi.UpdateOneAsync(x => x.Id == dto.Id, combined);
+
+            if (dto.DogadjajId != null && dto.DogadjajId != existing.DogadjajId)
+            {
+                if (!string.IsNullOrEmpty(existing.DogadjajId))
+                {
+                    var removeFilter = Builders<Dogadjaj>.Filter.Eq(x => x.Id, existing.DogadjajId);
+                    var removeUpdate = Builders<Dogadjaj>.Update.Pull(x => x.Rasporedi, existing.Id);
+                    await _dogadjaji.UpdateOneAsync(removeFilter, removeUpdate);
+                }
+
+                if (!string.IsNullOrWhiteSpace(dto.DogadjajId))
+                {
+                    var addFilter = Builders<Dogadjaj>.Filter.Eq(x => x.Id, dto.DogadjajId);
+                    var addUpdate = Builders<Dogadjaj>.Update.AddToSet(x => x.Rasporedi, existing.Id);
+                    await _dogadjaji.UpdateOneAsync(addFilter, addUpdate);
+                }
+            }
         }
 
-        public async Task Obrisi(string id) =>
+        public async Task Obrisi(string id)
+        {
+            var raspored = await _rasporedi.Find(x => x.Id == id).FirstOrDefaultAsync();
+            if (raspored == null)
+            {
+                return;
+            }
+
             await _rasporedi.DeleteOneAsync(x => x.Id == id);
+
+            if (!string.IsNullOrEmpty(raspored.DogadjajId))
+            {
+                var filter = Builders<Dogadjaj>.Filter.Eq(x => x.Id, raspored.DogadjajId);
+                var update = Builders<Dogadjaj>.Update.Pull(x => x.Rasporedi, raspored.Id);
+                await _dogadjaji.UpdateOneAsync(filter, update);
+            }
+
+            if (raspored.Aktivnosti != null && raspored.Aktivnosti.Count > 0)
+            {
+                var filter = Builders<Aktivnost>.Filter.In(x => x.Id, raspored.Aktivnosti);
+                var update = Builders<Aktivnost>.Update.Unset(x => x.RasporedId);
+                await _aktivnosti.UpdateManyAsync(filter, update);
+            }
+        }
     }
 }

--- a/src/frontend/EventOrganizerWeb/src/services/activitiesApi.js
+++ b/src/frontend/EventOrganizerWeb/src/services/activitiesApi.js
@@ -32,7 +32,8 @@ export async function create(dto){
     Lokacija: dto?.Lokacija || dto?.lokacija || '',
     Dan: dto?.Dan || dto?.dan || '',
     Dogadjaj: dto?.Dogadjaj || dto?.dogadjaj || dto?.DogadjajId || dto?.dogadjajId || '',
-    Tip: dto?.Tip || dto?.tip || 'Ostalo'
+    Tip: dto?.Tip || dto?.tip || 'Ostalo',
+    RasporedId: dto?.RasporedId || dto?.rasporedId || dto?.Raspored || dto?.raspored || ''
   };
   const { data } = await api.post('aktivnosti/kreiraj', payload);
   return data;
@@ -49,6 +50,7 @@ export async function update(id, dto){
     Dan: dto?.Dan,
     Dogadjaj: dto?.Dogadjaj,
     Tip: dto?.Tip,
+    RasporedId: dto?.RasporedId,
   };
   const { data } = await api.put(`aktivnosti/azuriraj/${id}`, payload);
   return data;

--- a/src/frontend/EventOrganizerWeb/src/services/newEventApi.js
+++ b/src/frontend/EventOrganizerWeb/src/services/newEventApi.js
@@ -80,3 +80,10 @@ export async function updateActivityIds(eventId, activityIds){
   const payload = { ...rest, Id: eventId, Aktivnosti: Array.from(new Set(activityIds || [])) };
   return await updateDraft(eventId, payload);
 }
+
+export async function updateScheduleIds(eventId, scheduleIds){
+  const ev = await getById(eventId);
+  const { Id, _id, ...rest } = ev || {};
+  const payload = { ...rest, Id: eventId, Rasporedi: Array.from(new Set(scheduleIds || [])) };
+  return await updateDraft(eventId, payload);
+}

--- a/src/frontend/EventOrganizerWeb/src/services/schedulesApi.js
+++ b/src/frontend/EventOrganizerWeb/src/services/schedulesApi.js
@@ -1,0 +1,51 @@
+// src/services/schedulesApi.js
+import api from './api';
+
+export function normalizeId(entity){
+  return entity?.Id || entity?._id || entity?.id || null;
+}
+
+function matchesEvent(entity, eventId){
+  if (!eventId) return false;
+  const raw = entity?.DogadjajId ?? entity?.dogadjajId ?? entity?.Dogadjaj ?? entity?.dogadjaj;
+  return raw && String(raw) === String(eventId);
+}
+
+export async function listByEvent(eventId){
+  if (!eventId) return [];
+  const { data } = await api.get(`rasporedi/dogadjaj/${eventId}`);
+  const list = Array.isArray(data) ? data : [];
+  return list.filter(item => matchesEvent(item, eventId));
+}
+
+export async function create(dto){
+  const payload = {
+    Naziv: dto?.Naziv || dto?.naziv || '',
+    Opis: dto?.Opis || dto?.opis || '',
+    Lokacija: dto?.Lokacija || dto?.lokacija || '',
+    Dan: dto?.Dan || dto?.dan || '',
+    DogadjajId: dto?.DogadjajId || dto?.dogadjajId || dto?.Dogadjaj || dto?.dogadjaj || '',
+  };
+  const { data } = await api.post('rasporedi/kreiraj', payload);
+  return data;
+}
+
+export async function update(id, dto){
+  const payload = {
+    Id: id,
+    Naziv: dto?.Naziv,
+    Opis: dto?.Opis,
+    Lokacija: dto?.Lokacija,
+    Dan: dto?.Dan,
+    DogadjajId: dto?.DogadjajId,
+  };
+  const { data } = await api.put(`rasporedi/azuriraj/${id}`, payload);
+  return data;
+}
+
+export async function remove(id){
+  const { data } = await api.delete(`rasporedi/obrisi/${id}`);
+  return data;
+}
+
+export { matchesEvent };

--- a/src/frontend/EventOrganizerWeb/src/styles/NewEvent/activities.css
+++ b/src/frontend/EventOrganizerWeb/src/styles/NewEvent/activities.css
@@ -191,3 +191,158 @@
   padding: 18px;
   color: var(--ne-text-muted);
 }
+
+.act-left {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.act-schedule-meta {
+  margin-bottom: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.act-schedule-meta h4 {
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: var(--ne-text-strong);
+}
+
+.act-schedule-meta p {
+  margin: 0;
+  color: var(--ne-text-muted);
+  font-size: 0.9rem;
+}
+
+.act-schedule-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  font-size: 0.85rem;
+  color: var(--ne-text);
+}
+
+.schedule-list {
+  background: var(--ne-surface-alt);
+  border-radius: 16px;
+  border: 1px solid var(--ne-border);
+  padding: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
+}
+
+.schedule-list__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.schedule-list__header h4 {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--ne-text-strong);
+}
+
+.schedule-list__counter {
+  background: rgba(139, 92, 246, 0.15);
+  color: var(--ne-text);
+  border-radius: 999px;
+  padding: 4px 10px;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.schedule-list__items {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.schedule-list__item {
+  border: 1px solid transparent;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.02);
+  transition: border-color 0.2s ease, background 0.2s ease;
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px;
+  align-items: center;
+}
+
+.schedule-list__item:hover {
+  border-color: var(--ne-border-strong);
+}
+
+.schedule-list__item--active {
+  border-color: var(--ne-btn-primary);
+  background: rgba(139, 92, 246, 0.12);
+}
+
+.schedule-list__select {
+  background: transparent;
+  border: none;
+  text-align: left;
+  padding: 0;
+  cursor: pointer;
+  flex: 1;
+  color: var(--ne-text);
+}
+
+.schedule-list__select:disabled {
+  cursor: not-allowed;
+  opacity: 0.7;
+}
+
+.schedule-list__name {
+  display: block;
+  font-weight: 600;
+}
+
+.schedule-list__meta {
+  display: block;
+  font-size: 0.8rem;
+  color: var(--ne-text-muted);
+}
+
+.schedule-list__actions {
+  display: flex;
+  gap: 8px;
+}
+
+.schedule-list__action {
+  padding: 6px 12px;
+  font-size: 0.8rem;
+}
+
+.schedule-list__empty {
+  font-size: 0.9rem;
+  color: var(--ne-text-muted);
+}
+
+.act-note--inline {
+  margin-top: 16px;
+  margin-bottom: 0;
+  font-size: 0.85rem;
+}
+
+@media (max-width: 900px) {
+  .schedule-list__item {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .schedule-list__actions {
+    justify-content: flex-end;
+  }
+}


### PR DESCRIPTION
## Summary
- extend backend schedules and activities models/services to link activities to specific schedules and keep event drafts in sync
- add a dedicated schedules API client and refactor the organizer activities step to manage schedules alongside their activities
- refresh styles to present the schedule list, metadata, and activity table cohesively in the new layout

## Testing
- dotnet build *(fails: command not found in container)*
- npm test -- --watchAll=false --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_e_690d39a31568832a93750bebf071fa4d