### PR TITLE
Refine schedule management workflow in Activities

### DIFF
--- a/src/frontend/EventOrganizerWeb/src/styles/NewEvent/activities.css
+++ b/src/frontend/EventOrganizerWeb/src/styles/NewEvent/activities.css
@@ -28,6 +28,23 @@
   color: var(--ne-text-strong);
 }
 
+.act-form__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.act-form__header h3 {
+  margin-bottom: 0;
+}
+
+.act-form__body {
+  display: flex;
+  flex-direction: column;
+}
+
 .act-field {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- rework the Activities schedule form to support create, view, and edit modes with explicit "Dodaj raspored" toggling and state restoration
- update schedule selection and action handlers so saving locks the form until "Izmeni" is pressed and list actions respect the new flow
- add layout styles for the schedule form header/body to align the refreshed UI

## Testing
- CI=true npm test -- --watch=false --passWithNoTests

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d406110a4832a8e87e7844a7357a0)